### PR TITLE
Update package.json to prevent creating source map

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "scripts": {
     "start": "react-scripts start",
-    "build": "react-scripts build",
+    "build": "GENERATE_SOURCEMAP=false react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },


### PR DESCRIPTION
`create-react-app`을 통해 만든 프로젝트에서 고질적으로 source map 파일이 노출되는 사례가 있습니다.

source map 파일은 브라우저 개발자 도구를 통해 빌드되기 이전의 파일을 확인할 수 있게 만들어 줘, 문제가 발생했을 때 손쉽게 파악할 수 있습니다. app.js에 대한 source map 파일은 app.js.map으로 생성이 됩니다.

하지만 이를 악용하게될 경우 FE 수준의 비즈니스 로직을 쉽게 파악하여 공격에 이용할 수 있어, source map 파일은 되도록 노출시키지 않는게 좋습니다.

참고링크: https://github.com/facebook/create-react-app/blob/main/docusaurus/docs/advanced-configuration.md