### PR TITLE
fix: devDependencies로 라이브러리를 이동 시킵니다

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,6 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@testing-library/jest-dom": "^5.14.1",
-    "@testing-library/react": "^11.2.7",
-    "@testing-library/user-event": "^12.8.3",
     "jquery": "^3.6.0",
     "qs": "^6.7.0",
     "react": "^17.0.2",
@@ -14,6 +11,11 @@
     "react-router-dom": "^5.2.0",
     "react-scripts": "4.0.3",
     "web-vitals": "^1.1.2"
+  },
+  "devDependencies": {
+    "@testing-library/jest-dom": "^5.14.1",
+    "@testing-library/react": "^11.2.7",
+    "@testing-library/user-event": "^12.8.3"
   },
   "scripts": {
     "start": "react-scripts start",


### PR DESCRIPTION
안녕하세요.
package.json에서 설정된 dependencies 중에 테스트용으로 사용되는 라이브러리들을 확인했습니다.
- "@testing-library/jest-dom"
- "@testing-library/react"
- "@testing-library/user-event"

해당 테스트 라이브러리는 개발시에만 사용되기에 devDependencies로 이동하는 작업을 하였습니다.
참조 부탁드립니다.
감사합니다.