### PR TITLE
모바일메뉴에서 클릭 시 자동숨기처리 및 반응형 디자인 설정 추가 반영을 요청 합니다.

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2,6 +2,8 @@
 <html>
   <head>
     <title>React App</title>
+    <!-- 아래 뷰포트 설정이 있어야 크롬 개발자도구에서 디바이스별로 반응형 미리보기가 가능하다.: 2023.04.13(목) 김일국 추가 -->
+    <meta name="viewport" content="width=device-width">
   </head>
   <body>
     <div id="root"></div>

--- a/src/components/EgovHeader.jsx
+++ b/src/components/EgovHeader.jsx
@@ -18,6 +18,11 @@ function EgovHeader({ loginUser, onChangeLogin }) {
 
     const logInHandler = () => { // 로그인 정보 없을 시
         navigate(URL.LOGIN);
+		// PC와 Mobile 열린메뉴 닫기: 2023.04.13(목) 김일국 추가
+		document.querySelector('.all_menu.WEB').classList.add('closed');
+        document.querySelector('.btnAllMenu').classList.remove('active');
+        document.querySelector('.btnAllMenu').title = '전체메뉴 닫힘';
+		document.querySelector('.all_menu.Mobile').classList.add('closed');
     }
     const logOutHandler = () => {// 로그인 정보 존재할 때
         const logOutUrl = '/uat/uia/actionLogoutAPI.do';
@@ -32,6 +37,11 @@ function EgovHeader({ loginUser, onChangeLogin }) {
                     sessionStorage.setItem('loginUser', JSON.stringify({"id":""}));
                     window.alert("로그아웃되었습니다!");
                     navigate(URL.MAIN);
+					// PC와 Mobile 열린메뉴 닫기: 2023.04.13(목) 김일국 추가
+					document.querySelector('.all_menu.WEB').classList.add('closed');
+	                document.querySelector('.btnAllMenu').classList.remove('active');
+	                document.querySelector('.btnAllMenu').title = '전체메뉴 닫힘';
+					document.querySelector('.all_menu.Mobile').classList.add('closed');
                 }
             }
         );

--- a/src/css/response.css
+++ b/src/css/response.css
@@ -26,7 +26,8 @@
     .user_info_m .person {color: #169bd5; font-weight: 700; letter-spacing: -1px;}
     .user_info_m .person::before {content: ""; display: inline-block; width: 22px; height: 22px; margin-right: 9px; background: url(css/images/ico_person.png) no-repeat; background-size: contain; vertical-align: -6px;}
     .user_info_m .login {width: 85px; height: 30px; margin-top: 20px; border-radius: 15px; color: #fff; font-size: 12px; line-height: 30px; text-align: center; background: #169bd5;}
-    .user_info_m .logout {margin-left: 5px; color: #222; font-weight: 700; text-decoration: underline;}
+    /* Mobile 로그아웃 버튼 디자인 이쁘게 적용: 2023.04.13(목) 김일국 추가 */
+    .user_info_m .logout {color: #222; font-weight: 700; padding: 0 20px; border-radius: 15px; color: #fff; font-size: 14px; line-height: 30px; background: #169bd5; vertical-align: middle;}
     .user_info_m .close {display: block; position: absolute; right: 20px; top: 24px; width: 21px; height: 21px; background: url(css/images/ico_close_black44.png) no-repeat; background-size: contain;}
 
     .all_menu.Mobile .menu {border-top: 10px solid #f5f6f7;}

--- a/src/js/ui.js
+++ b/src/js/ui.js
@@ -42,7 +42,11 @@ export default function initPage() {
                 document.querySelector('.btnAllMenu').title = '전체메뉴 닫힘';
             }
         });
-
+		// Mobile 서브메뉴 항목 클릭시 메뉴 닫기: 2023.04.13(목) 김일국 추가
+        document.querySelectorAll('.all_menu.Mobile .submenu a')
+			.forEach(el => el.addEventListener('click', (e) =>  {
+            	document.querySelector('.all_menu.Mobile').classList.add('closed');
+        }));
         // 모바일 하위 메뉴 열고 닫기
         document.querySelectorAll('.all_menu.Mobile h3 a')
             .forEach(el => el.addEventListener('click', (e) =>  {


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [X] 버그수정 Bug fixes
- [X] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.
- 1). src/js/ui.js : 라인45 위치의 코드추가
- 위 코드 설명 : Mobile 서브메뉴 항목 클릭시 메뉴 닫기 기능이 작동하도록 코드를 추가하였다.
- 2). src/components/EgovHeader.jsx : 라인21, 라인40 위치의 코드추가
- 위 라인21코드 설명 : 로그인 버튼 클릭 시 PC와 Mobile 열린메뉴 닫기 기능이 작동하도록 코드를 추가하였다.
- 위 라인40코드 설명 : 로그아웃 버튼 클릭 시 PC와 Mobile 열린메뉴 닫기 기능이 작동하도록 코드를 추가하였다.
- 3). src/css/response.css : 라인30 위치의 코드추가
- 위 코드 설명 : Mobile 로그아웃 버튼 디자인 스타일을 로그인과 같은 디자인으로 적용.
- 4). public/index.html : 라인6 위치의 코드추가
- 위 코드 설명 : 뷰포트 설정이 있어야 크롬 개발자도구에서 디바이스별로 반응형 미리보기가 가능하기 때문에 코드를 추가 하였다.

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [ ] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [X] Chrome
- [ ] Firefox
- [X] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡쳐 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡쳐 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.
- 1). Mobile 서브메뉴 항목 클릭시 메뉴 닫기 기능이 작동
- 위 내용 설명 : 모바일에서 [주요사업 소개]와 같은 서브메뉴를 클릭하면 기존에는 메뉴가 그대로 있었으나, 수정 후 메뉴가 닫히면서 페이지 이동이 가능하게 되었다. (아래)
- 수정 전 서브 메뉴를 클릭 해도 메뉴가 그대로 사라지지 않고 있다.(아래)
![image](https://user-images.githubusercontent.com/52336625/231406923-fefbe6fb-fca1-4488-b6eb-45cb75c8d386.png)
- 수정 후 서브 메뉴를 클릭 하면 메뉴가 자동으로 사라지면서 이동한 화면이 보인다.(아래)
![image](https://user-images.githubusercontent.com/52336625/231407159-e301a776-9e23-49aa-94d4-c4a2d6b624e0.png)
- 2). 로그인/로그아웃 버튼 클릭 시 PC와 Mobile 열린메뉴 닫기 기능이 작동하도록 코드를 추가하였다.
- 위 내용 설명 : 기존에는 PC 와 Mobile에서 메뉴가 열린 상태에서 로그인/로그아웃 버튼을 클릭해도 메뉴가 열린 그대로 있었으나, 수정 후 메뉴가 닫히면서 페이지 이동이 가능하게 되었다. (아래)
- 수정 전 메뉴가 열린 상태에서 로그인 버튼 클릭 시 화면(아래)
![image](https://user-images.githubusercontent.com/52336625/231401009-e395a685-d2d5-4972-9899-7fe29c4a90dc.png)
- 수정 후 메뉴가 열린 상태에서 로그인 버튼 클릭 시 화면(아래)
![image](https://user-images.githubusercontent.com/52336625/231400910-f3458ce6-46bd-449d-b13a-09e0b81bd143.png)
- 3). Mobile 로그아웃 버튼 디자인 스타일을 로그인과 같은 디자인으로 적용.(아래)
- 수정 전 모바일 에서 로그인 후 화면(아래)
![image](https://user-images.githubusercontent.com/52336625/231401637-90b206a9-d89e-4527-9009-943b37e730f2.png)
- 수정 후 모바일 에서 로그인 후 화면(아래)
![image](https://user-images.githubusercontent.com/52336625/231401964-672952d1-d90c-4770-bb2e-300d1f1c695c.png)
- 4). 뷰포트 설정이 있어야 크롬 개발자도구에서 디바이스별로 반응형 미리보기가 가능하기 때문에 코드를 추가(아래)
- 뷰 포트 코드 추가 전 크롬 개발자도구 화면(아래)
![image](https://user-images.githubusercontent.com/52336625/231402743-dc8fa38f-757b-4582-99ec-b538ee1fea83.png)
- 뷰 포트 코드 추가 후 크롬 개발자도구 화면(아래)
![image](https://user-images.githubusercontent.com/52336625/231402478-57ebb6ef-44f7-43d3-b957-f8938df18af9.png)

