### PR TITLE
모바일에서 관리자 메뉴가 동적으로 추가되었을 때 서브메뉴가 정상 작동되도록 코드 추가

### DIFF
--- a/src/js/ui.js
+++ b/src/js/ui.js
@@ -1,7 +1,32 @@
 let init;
 
 export default function initPage() {
-
+	//모바일에서 관리자 메뉴가 동적으로 추가되었을 때 서브메뉴가 정상 작동되도록 코드 추가 : 2023.04.14(금) 김일국 추가
+	const sessionUser = sessionStorage.getItem('loginUser');
+    const sessionUserId = JSON.parse(sessionUser)?.id;
+	if(sessionUserId=='admin'){
+	    // Mobile 서브메뉴 항목 클릭시 메뉴 닫기
+        document.querySelectorAll('.all_menu.Mobile .submenu a')
+			.forEach(el => el.addEventListener('click', () =>  {
+            	document.querySelector('.all_menu.Mobile').classList.add('closed');
+        }));
+        // 모바일 관리자 하위 메뉴 열고 닫기
+		const nodes = document.querySelectorAll('.all_menu.Mobile h3 a');
+		const last_submenu = nodes[nodes.length- 1];
+		last_submenu.addEventListener('click', (e) => {
+			e.preventDefault();
+			const el = e.target;
+			el.classList.toggle('active');
+			const submenu = el.parentElement.nextElementSibling;
+            if (submenu.matches('.closed')) {
+                submenu.style.height = submenu.scrollHeight + 'px';
+                submenu.classList.remove('closed');
+            } else {
+                submenu.classList.add('closed');
+                submenu.style.height = '';
+            }
+		});
+	}
     if (init) return;
     init = true;
 


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.
- src/js/ui.js 파일의 라인4 부분 추가 : 모바일 화면에서 관리자로 로그인 했을 때, [사이트관리] 메뉴 클릭 시 서브메뉴 출력이 작동하지 않는 버그 입니다. 
- 원인은 관리자 로그인일 때 동적으로 [사이트관리] 메뉴가 보이게 되는데, 이 때 자바스크립트가 동적으로 생성된 메뉴 객체를 인식하지 못하는 문제입니다. ui.js 파일 라인4번 부터 아래 관리자 조건을 추가 하였습니다.
```
//모바일에서 관리자 메뉴가 동적으로 추가되었을 때 서브메뉴가 정상 작동되도록 코드 추가 : 2023.04.14(금) 김일국 추가
  const sessionUser = sessionStorage.getItem('loginUser');
  const sessionUserId = JSON.parse(sessionUser)?.id;
  if(sessionUserId=='admin'){
	// Mobile 서브메뉴 항목 클릭시 메뉴 닫기
        document.querySelectorAll('.all_menu.Mobile .submenu a')
	  .forEach(el => el.addEventListener('click', () =>  {
             document.querySelector('.all_menu.Mobile').classList.add('closed');
        }));
      // 모바일 관리자 하위 메뉴 열고 닫기
      const nodes = document.querySelectorAll('.all_menu.Mobile h3 a');
      const last_submenu = nodes[nodes.length- 1];
      last_submenu.addEventListener('click', (e) => {
	      e.preventDefault();
	      const el = e.target;
	      el.classList.toggle('active');
	      const submenu = el.parentElement.nextElementSibling;
                if (submenu.matches('.closed')) {
                    submenu.style.height = submenu.scrollHeight + 'px';
                    submenu.classList.remove('closed');
                } else {
                    submenu.classList.add('closed');
                    submenu.style.height = '';
                }
      });
  }
```
## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [ ] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [X] Chrome
- [ ] Firefox
- [X] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡쳐 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡쳐 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.
- 작업 전 화면 : 모바일에서 관리자로 로그인 후 [사이트관리] 메뉴를 클릭해도 서브 메뉴가 나타나지 않는다(아래).
![image](https://user-images.githubusercontent.com/52336625/231741456-1bba7778-ea21-424e-95fc-f1cc6c12dfbb.png)
- 작업 후 화면 : 모바일에서 관리자로 로그인 후 [사이트관리] 메뉴를 클릭해도 서브 메뉴가 나타나고, 정상 작동한다.(아래)
![image](https://user-images.githubusercontent.com/52336625/231742869-61b37d58-7961-40d8-90e7-848a54353300.png)