### PR TITLE
1).API백엔드 단에서 넘어온 메세지 변수명 출력부분 오타 2).에러발생 후 에러페이지에서 이전페이지로 이동 후 햄버거메뉴 작동오류

### DIFF
--- a/src/components/EgovAttachFile.jsx
+++ b/src/components/EgovAttachFile.jsx
@@ -50,7 +50,7 @@ function EgovAttachFile({ boardFiles, mode, fnChangeFile, fnDeleteFile, posblAtc
                     alert("첨부파일이 삭제되었습니다.");
                     fnChangeFile({});
                 } else {
-                    navigate({pathname: URL.ERROR}, {state: {msg : resp.message}});
+                    navigate({pathname: URL.ERROR}, {state: {msg : resp.resultMessage}});
                 }
             }
         );

--- a/src/components/EgovError.jsx
+++ b/src/components/EgovError.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 
-function EgovError() {
+function EgovError(prop) { // index.jsx 라우터에서 보내온 이전 페이지 location 객체를 사용한다.
     const navigate = useNavigate();
 	const location = useLocation();    
 
@@ -12,7 +12,9 @@ function EgovError() {
     }
 
     const goBack = () => {
-      navigate(-1, { replace: true });
+      //에러페이지로 이동하면 헤더가 없어지기 때문에 에러 이전페이지로 돌아갈 때 로딩한 ui.js가 제대로 작동하지 않는다. 그래서, 이전 URL을 재 로딩하는 코드를 추가한다. 
+	  navigate(prop.prevUrl.pathname); // porp 속성 값을 이전 URL로 사용한다.
+      navigate(0, { replace: true });// 이전 URL을 현재 페이지 인식하고 재 로딩하는 코드.
     }
 
     return (

--- a/src/pages/admin/board/EgovAdminBoardEdit.jsx
+++ b/src/pages/admin/board/EgovAdminBoardEdit.jsx
@@ -160,7 +160,7 @@ function EgovAdminBoardEdit(props) {
                             if (Number(resp.resultCode) === Number(CODE.RCV_SUCCESS)) {
                                 navigate({ pathname: URL.ADMIN_BOARD });
                             } else {
-                                navigate({pathname: URL.ERROR}, {state: {msg : resp.message}});
+                                navigate({pathname: URL.ERROR}, {state: {msg : resp.resultMessage}});
                             }
                         }
                     );
@@ -184,7 +184,7 @@ function EgovAdminBoardEdit(props) {
                         if (Number(resp.resultCode) === Number(CODE.RCV_SUCCESS)) {
                             navigate({ pathname: URL.ADMIN_BOARD });
                         } else {
-                            navigate({pathname: URL.ERROR}, {state: {msg : resp.message}});
+                            navigate({pathname: URL.ERROR}, {state: {msg : resp.resultMessage}});
                         }
                     }
                 );

--- a/src/pages/admin/gallery/EgovAdminGalleryDetail.jsx
+++ b/src/pages/admin/gallery/EgovAdminGalleryDetail.jsx
@@ -73,7 +73,7 @@ function EgovAdminGalleryDetail(props) {
                     navigate(URL.ADMIN_GALLERY ,{ replace: true });
                 } else {
                     // alert("ERR : " + resp.message);
-                    navigate({pathname: URL.ERROR}, {state: {msg : resp.message}});
+                    navigate({pathname: URL.ERROR}, {state: {msg : resp.resultMessage}});
                 }
 
             }

--- a/src/pages/admin/gallery/EgovAdminGalleryEdit.jsx
+++ b/src/pages/admin/gallery/EgovAdminGalleryEdit.jsx
@@ -139,7 +139,7 @@ function EgovAdminGalleryEdit(props) {
                         navigate(URL.INFORM_GALLERY, {state:{bbsId : bbsId}});
                     } else {
                         // alert("ERR : " + resp.message);
-                        navigate({pathname: URL.ERROR}, {state: {msg : resp.message}});
+                        navigate({pathname: URL.ERROR}, {state: {msg : resp.resultMessage}});
                     }
                 }
             );

--- a/src/pages/admin/manager/EgovAdminPasswordUpdate.jsx
+++ b/src/pages/admin/manager/EgovAdminPasswordUpdate.jsx
@@ -56,7 +56,7 @@ function EgovAdminPasswordUpdate(props) {
                         navigate({ pathname: URL.MAIN }, { replace: true });
                     } else {
 						alert("Fail 변경되지 않았습니다. 다시 시도해 주세요.");
-						//navigate({pathname: URL.ERROR}, {state: {msg : resp.message}});
+						navigate({pathname: URL.ERROR}, {state: {msg : resp.resultMessage}}); //에러메세지 변수명 변경
                     }
                 }
             );

--- a/src/pages/admin/notice/EgovAdminNoticeDetail.jsx
+++ b/src/pages/admin/notice/EgovAdminNoticeDetail.jsx
@@ -71,7 +71,7 @@ function EgovAdminNoticeDetail(props) {
                     alert("게시글이 삭제되었습니다.")
                     navigate(URL.ADMIN_NOTICE ,{ replace: true });
                 } else {
-                    navigate({pathname: URL.ERROR}, {state: {msg : resp.message}});
+                    navigate({pathname: URL.ERROR}, {state: {msg : resp.resultMessage}});
                 }
 
             }

--- a/src/pages/admin/notice/EgovAdminNoticeEdit.jsx
+++ b/src/pages/admin/notice/EgovAdminNoticeEdit.jsx
@@ -139,7 +139,7 @@ function EgovAdminNoticeEdit(props) {
                         navigate(URL.INFORM_NOTICE, {state:{bbsId : bbsId}});
                     } else {
                         // alert("ERR : " + resp.message);
-                        navigate({pathname: URL.ERROR}, {state: {msg : resp.message}});
+                        navigate({pathname: URL.ERROR}, {state: {msg : resp.resultMessage}});
                     }
                 }
             );

--- a/src/pages/admin/schedule/EgovAdminScheduleDetail.jsx
+++ b/src/pages/admin/schedule/EgovAdminScheduleDetail.jsx
@@ -96,7 +96,7 @@ function EgovAdminScheduleDetail(props) {
                     navigate(URL.ADMIN_SCHEDULE ,{ replace: true });
                 } else {
                     // alert("ERR : " + resp.message);
-                    navigate({pathname: URL.ERROR}, {state: {msg : resp.message}});
+                    navigate({pathname: URL.ERROR}, {state: {msg : resp.resultMessage}});
                 }
 
             }

--- a/src/pages/admin/schedule/EgovAdminScheduleEdit.jsx
+++ b/src/pages/admin/schedule/EgovAdminScheduleEdit.jsx
@@ -126,7 +126,7 @@ function EgovAdminScheduleEdit(props) {
                     if (Number(resp.resultCode) === Number(CODE.RCV_SUCCESS)) {
                         navigate({ pathname: URL.ADMIN_SCHEDULE });
                     } else {
-                        navigate({pathname: URL.ERROR}, {state: {msg : resp.message}});
+                        navigate({pathname: URL.ERROR}, {state: {msg : resp.resultMessage}});
                     }
                 }
             );

--- a/src/pages/admin/usage/EgovAdminUsageEdit.jsx
+++ b/src/pages/admin/usage/EgovAdminUsageEdit.jsx
@@ -150,7 +150,7 @@ function EgovAdminUsageEdit(props) {
                     if (Number(resp.resultCode) === Number(CODE.RCV_SUCCESS)) {
                             navigate({ pathname: URL.ADMIN_USAGE });
                     } else {
-                            navigate({pathname: URL.ERROR}, {state: {msg : resp.message}});
+                            navigate({pathname: URL.ERROR}, {state: {msg : resp.resultMessage}});
                     }
                 }
             );

--- a/src/pages/inform/gallery/EgovGalleryDetail.jsx
+++ b/src/pages/inform/gallery/EgovGalleryDetail.jsx
@@ -74,7 +74,7 @@ function EgovGalleryDetail(props) {
                     alert("게시글이 삭제되었습니다.")
                     navigate(URL.INFORM_GALLERY ,{ replace: true });
                 } else {
-                    navigate({pathname: URL.ERROR}, {state: {msg : resp.message}});
+                    navigate({pathname: URL.ERROR}, {state: {msg : resp.resultMessage}});
                 }
 
             }

--- a/src/pages/inform/gallery/EgovGalleryEdit.jsx
+++ b/src/pages/inform/gallery/EgovGalleryEdit.jsx
@@ -139,7 +139,7 @@ function EgovGalleryEdit(props) {
                         navigate(URL.INFORM_GALLERY, {state:{bbsId : bbsId}});
                     } else {
                         // alert("ERR : " + resp.message);
-                        navigate({pathname: URL.ERROR}, {state: {msg : resp.message}});
+                        navigate({pathname: URL.ERROR}, {state: {msg : resp.resultMessage}});
                     }
                 }
             );

--- a/src/pages/inform/notice/EgovNoticeDetail.jsx
+++ b/src/pages/inform/notice/EgovNoticeDetail.jsx
@@ -73,7 +73,7 @@ function EgovNoticeDetail(props) {
                     alert("게시글이 삭제되었습니다.")
                     navigate(URL.INFORM_NOTICE ,{ replace: true });
                 } else {
-                    navigate({pathname: URL.ERROR}, {state: {msg : resp.message}});
+                    navigate({pathname: URL.ERROR}, {state: {msg : resp.resultMessage}});
                 }
 
             }

--- a/src/pages/inform/notice/EgovNoticeEdit.jsx
+++ b/src/pages/inform/notice/EgovNoticeEdit.jsx
@@ -139,7 +139,7 @@ function EgovNoticeEdit(props) {
                         navigate(URL.INFORM_NOTICE, {state:{bbsId : bbsId}});
                     } else {
                         // alert("ERR : " + resp.message);
-                        navigate({pathname: URL.ERROR}, {state: {msg : resp.message}});
+                        navigate({pathname: URL.ERROR}, {state: {msg : resp.resultMessage}});
                     }
                 }
             );

--- a/src/routes/index.jsx
+++ b/src/routes/index.jsx
@@ -1,5 +1,5 @@
-import React, { useEffect, useState } from 'react';
-import { Navigate, Routes, Route } from 'react-router-dom';
+import React, { useEffect, useState, useRef } from 'react';
+import { Navigate, Routes, Route, useLocation } from 'react-router-dom';
 
 import URL from 'constants/url';
 import CODE from 'constants/code';
@@ -67,11 +67,24 @@ import EgovAdminPasswordUpdate from 'pages/admin/manager/EgovAdminPasswordUpdate
 
 import initPage from 'js/ui';
 
+// 에러 페이지와 같은 상단(EgovHeader) 소스가 제외된 페이지에서 ui.js의 햄버거버튼 작동오류가 발생한다. 
+// 즉, ui.js가 작동되지 않아서 재 로딩 해야 한다. 그래서, useRef객체를 사용하여 이전 페이지 URL을 구하는 코드 추가(아래)
+const usePrevLocation = (location) => {
+	const prevLocRef = useRef(location);
+	useEffect(()=>{
+		prevLocRef.current = location;
+	},[location]);
+	return prevLocRef.current;
+}
+
 const RootRoutes = () => {
+  //useLocation객체를 이용하여 에러페이시 이동 전 location 객체를 저장하는 코드 추가(아래 2줄) */}
+  const location = useLocation();
+  const prevLocation = usePrevLocation(location);
 
   return (
-      <Routes>
-        <Route path={URL.ERROR} element={<EgovError />} />
+      <Routes> {/* 에러페지시 호출시 이전 prevUrl객체를 전송하는 코드 추가(아래) */}
+        <Route path={URL.ERROR} element={<EgovError prevUrl={prevLocation} />} />
         <Route path="*" element={<SecondRoutes/>} />
       </Routes>
   )


### PR DESCRIPTION
## 수정 사유 Reason for modification
- 1). API백엔드 단에서 넘어온 에러 메세지 값이 출력 되지 않는다.
- 위 원인 : API백엔드 단 ResultVO의 멤버변수명과 리액트 단의 응답 변수명이 일치하지 않아서 발생되었다.
- 2). 에러 발생 후 에러 페이지에서 이전 페이지로 이동 후 햄버거 메뉴가 작동하지 않는다.
- 위 원인 : 에러페이지가 상단,레프트,하단이 제외된 페이지이기 때문에 기존 navigate(-1, { replace: true })로 페이지 이동 시 ui.js가 작동하지 못하기 때문이다.
소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.
아래 2 부분:
- 1). API백엔드 단에서 넘어온 에러 메세지 값이 출력 되지 않는다.
- 위 수정사항 : 리액트앱 14개파일에서 사용된 다음 코드 msg : resp.message 를 msg : resp.resultMessage 로 응답 변수 명 변경

- 2). 에러 발생 후 에러 페이지에서 이전 페이지로 이동 후 햄버거 메뉴가 작동하지 않는다.
- 위 수정사항 : 아래 2가지
- index.jsp 라우터에서 이전 페이지Url을 에러페이지로 넘겨주는 속성 prevUrl 을 추가한다.(useRef객체와 useLocation객체사용)
- EgovError.jsx 에러 컴포넌트 페이지에서 prop.prevUrl.pathname 값을 사용하여 페이지를 명시적으로 이동한 후 navigate(0, { replace: true }) 함수로 강제로 새로고침 한다.(위 index.jsx 라우터에서 보내온 이전 페이지의 location객체를 prop로 사용한다.)

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [ ] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [X] Chrome
- [ ] Firefox
- [X] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡쳐 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡쳐 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.
- 수정 전 : 
- 1). API백엔드 단에서 보내온 메세지가 출력 되지 않는다.
- 2). 에러 페이지에서 이전 페이지로 이동 후 햄버거 메뉴가 작동하지 않는다.
- 수정 후
![image](https://user-images.githubusercontent.com/52336625/232429515-a49d0bda-8fa7-4686-b330-247c02f1df22.png)
