### PR TITLE
공지사항 목록에서 페이징 클릭 시 검색어, 검색조건 못 넘기는 에러 수정

### DIFF
--- a/src/pages/inform/notice/EgovNoticeList.jsx
+++ b/src/pages/inform/notice/EgovNoticeList.jsx
@@ -186,7 +186,7 @@ function EgovNoticeList(props) {
                         <div className="board_bot">
                             {/* <!-- Paging --> */}
                             <EgovPaging pagination={paginationInfo} moveToPage={passedPage => {
-                                retrieveList({ ...searchCondition, pageIndex: passedPage })
+                                retrieveList({ ...searchCondition, pageIndex: passedPage, searchCnd: cndRef.current.value, searchWrd: wrdRef.current.value })
                             }} />
                             {/* <!--/ Paging --> */}
                         </div>


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

알림마당 > 공지사항 목록에서 페이징 클릭 시 검색어, 검색조건을 못 넘겨 페이지가 변경됐을 때 전체 목록을 조회하게 되는 에러를 수정하였습니다.

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [ ] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [X] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡쳐 영상 Test screenshots or captured video

### **테스트 전**
**1. 제목에 1이 포함되는 12개의 게시글 검색**
![image](https://user-images.githubusercontent.com/46992992/232686046-8bd692ea-b81f-4c28-942c-d2cbea74d3de.png)
**2. 검색조건이 무시되며 페이지는 이동하지만 전체검색이 되는 에러 발견**
![image](https://user-images.githubusercontent.com/46992992/232686176-09a40c73-61eb-461a-9f72-780d7f24ba4c.png)

### **테스트 후**
**정상동작 확인**
![image](https://user-images.githubusercontent.com/46992992/232687022-6cd3525e-1aa2-4445-a616-b7c3a2bcf87a.png)
