### PR TITLE
시스템관리 메뉴인 /admin/으로 시작하는 URL은 모두 로그인이 필요하도록 코드추가

### DIFF
--- a/src/api/egovFetch.js
+++ b/src/api/egovFetch.js
@@ -25,7 +25,7 @@ export function requestFetch(url, requestOptions, handler, errorHandler) {
         })
         .then((resp) => {
             if (Number(resp.resultCode) === Number(CODE.RCV_ERROR_AUTH)) {
-                alert("Login Alert");
+                //alert("Login Alert"); //라우터파일에 /admin/으로 시작하는 URL은 모두 인증없이 접근 할 때 경고창이 나오도록 조치했기 때문에 제외했음.
                 sessionStorage.setItem('loginUser', JSON.stringify({"id":""}));
                 window.location.href = URL.LOGIN;
                 return false;


### PR DESCRIPTION
## 수정 사유 Reason for modification
- http://localhost:3000/admin/notice/
- http://localhost:3000/admin/manager/
- 위 URL처럼 시스템관리 메뉴인데, 로그인 없이도 직접 접근이 가능하기 때문에
- 시스템관리 메뉴는 /admin/으로 시작하는 URL로 모두 로그인이 필요하도록 통합 보안코드 추가

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [ ] 버그수정 Bug fixes
- [X] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.

- 1). 리액트에서 fetch URL접근 시 로그인 인증을 거치는 코드 수정.
- egovFetch.js 소스 라인28번 : API서버단에서 페이지별 인증값을 가져오는 구조는 그대로 두고, alert()로 로그인 인증 경고창 실행 부분만 제외 시켰다.)
- 2). 리액트에서 admin 폴더 URL접근 시 로그인 인증을 거치는 기존 라우터 코드 수정.
- index.jsx 소스 라인84번부터 : 기존 라우터 기능에 정규식을 사용해서 /admin/~으로 시작하는 URL에 접근 시 인증이 되어 있지 않으면, /login 으로 이동하도록 처리했다.
- alert() 로그인 인증 경고창도 1번 만 실행 되도록  useRef객체를 사용하여 전역 변수를 만들고, useState 상태객체를 사용하여 로그인 페이지 이동 전 사이트관리 페이지 잔상이 남지 않도록 처리했다.

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [ ] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [X] Chrome
- [ ] Firefox
- [X] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡쳐 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡쳐 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.
- 수정 전 : 로그인 하지 않은 상태에서 사이트관리 페이지에 접근이 가능하다.(아래)
![image](https://user-images.githubusercontent.com/52336625/232971430-79b8251a-8c08-4cda-bdaf-f5059a1fad54.png)
- 수정 후 : /admin/~ 으로 시작하는 URL은 관리자 인증을 거치도록 해서 사이트관리 페이지에 통합 보안을 걸어 두었다.(아래)
![image](https://user-images.githubusercontent.com/52336625/232971815-c7aa56b0-353f-4b38-a96d-801e953a66ac.png)
