### PR TITLE
단일파일 업로드에서 멀티파일 업로드로 기능개선

### DIFF
--- a/src/components/EgovAttachFile.jsx
+++ b/src/components/EgovAttachFile.jsx
@@ -58,7 +58,13 @@ function EgovAttachFile({ boardFiles, mode, fnChangeFile, fnDeleteFile, posblAtc
 
     function onChangeFileInput(e) {
         console.log("===>>> e = " + e.target.files[0]);
-        fnChangeFile(e.target.files[0]);
+        if (e.target.files.length+(boardFiles?.length||0) > posblAtchFileNumber) {
+		  alert('총 첨부파일 개수는 '+posblAtchFileNumber+' 까지 입니다.');
+		  e.target.value = null; // 파일 입력란 화면 초기화
+		  fnChangeFile({}); // 상위 컴포넌트의 저장된 값 초기화
+		  return false;
+	    }
+        fnChangeFile(e.target.files);
     }
 
     let filesTag = [];
@@ -102,9 +108,19 @@ function EgovAttachFile({ boardFiles, mode, fnChangeFile, fnDeleteFile, posblAtc
             <dd>
                 <span className="file_attach">
                     {filesTag}
-                    {(mode === CODE.MODE_CREATE) && <input name="file_0" id="egovComFileUploader" type="file" onChange={e => onChangeFileInput(e)}></input>}
+                    {(mode === CODE.MODE_CREATE) && 
+						<>
+						<input name="file_0" id="egovComFileUploader" type="file" multiple onChange={e => onChangeFileInput(e)}></input>
+						총 업로드 가능한 첨부파일 개수는 {posblAtchFileNumber} 개 입니다.
+						</>
+					}
                     {/* 첨부파일 1개 당  filesTag는 3개 요소(span, button, br)를 가진다 */}
-                    {(mode === CODE.MODE_MODIFY && (filesTag.length/3 < posblAtchFileNumber)) && <input name="file_0" id="egovComFileUploader" type="file" onChange={e => onChangeFileInput(e)}></input>}
+                    {(mode === CODE.MODE_MODIFY && (filesTag.length/3 < posblAtchFileNumber)) &&
+						<> 
+						<input name="file_0" id="egovComFileUploader" type="file" multiple onChange={e => onChangeFileInput(e)}></input>
+						현재 업로드 가능한 첨부파일 개수는 {posblAtchFileNumber-(filesTag.length/3)} 개 입니다.
+						</>
+					}
                 </span>
             </dd>
         </dl>

--- a/src/pages/admin/gallery/EgovAdminGalleryEdit.jsx
+++ b/src/pages/admin/gallery/EgovAdminGalleryEdit.jsx
@@ -211,7 +211,11 @@ function EgovAdminGalleryEdit(props) {
                                 <EgovAttachFile
                                     fnChangeFile={(attachfile) => {
                                         console.log("====>>> Changed attachfile file = ", attachfile);
-                                        setBoardDetail({ ...boardDetail, file_1: attachfile });
+                                        const arrayConcat = { ...boardDetail}; // 기존 단일 파일 업로드에서 다중파일 객체 추가로 변환(아래 for문으로)
+										for ( let i = 0; i < attachfile.length; i++) {
+											arrayConcat[`file_${i}`] = attachfile[i];
+										}
+                                        setBoardDetail(arrayConcat);
                                     }}
                                     fnDeleteFile={(deletedFile) => {
                                         console.log("====>>> Delete deletedFile = ", deletedFile);

--- a/src/pages/admin/notice/EgovAdminNoticeEdit.jsx
+++ b/src/pages/admin/notice/EgovAdminNoticeEdit.jsx
@@ -211,7 +211,11 @@ function EgovAdminNoticeEdit(props) {
                                 <EgovAttachFile
                                     fnChangeFile={(attachfile) => {
                                         console.log("====>>> Changed attachfile file = ", attachfile);
-                                        setBoardDetail({ ...boardDetail, file_1: attachfile });
+                                        const arrayConcat = { ...boardDetail}; // 기존 단일 파일 업로드에서 다중파일 객체 추가로 변환(아래 for문으로)
+										for ( let i = 0; i < attachfile.length; i++) {
+											arrayConcat[`file_${i}`] = attachfile[i];
+										}
+                                        setBoardDetail(arrayConcat);
                                     }}
                                     fnDeleteFile={(deletedFile) => {
                                         console.log("====>>> Delete deletedFile = ", deletedFile);

--- a/src/pages/admin/schedule/EgovAdminScheduleEdit.jsx
+++ b/src/pages/admin/schedule/EgovAdminScheduleEdit.jsx
@@ -324,7 +324,11 @@ function EgovAdminScheduleEdit(props) {
                             <EgovAttachFile
                                 fnChangeFile={(attachfile) => {
                                     console.log("====>>> Changed attachfile file = ", attachfile);
-                                    setScheduleDetail({ ...scheduleDetail, file_1: attachfile });
+                                    const arrayConcat = { ...scheduleDetail}; // 기존 단일 파일 업로드에서 다중파일 객체 추가로 변환(아래 for문으로)
+									for ( let i = 0; i < attachfile.length; i++) {
+										arrayConcat[`file_${i}`] = attachfile[i];
+									}
+                                    setScheduleDetail(arrayConcat);
                                 }}
                                 fnDeleteFile={(deletedFile) => {
                                     console.log("====>>> Delete deletedFile = ", deletedFile);

--- a/src/pages/inform/gallery/EgovGalleryEdit.jsx
+++ b/src/pages/inform/gallery/EgovGalleryEdit.jsx
@@ -211,7 +211,11 @@ function EgovGalleryEdit(props) {
                                 <EgovAttachFile
                                     fnChangeFile={(attachfile) => {
                                         console.log("====>>> Changed attachfile file = ", attachfile);
-                                        setBoardDetail({ ...boardDetail, file_1: attachfile });
+                                        const arrayConcat = { ...boardDetail}; // 기존 단일 파일 업로드에서 다중파일 객체 추가로 변환(아래 for문으로)
+										for ( let i = 0; i < attachfile.length; i++) {
+											arrayConcat[`file_${i}`] = attachfile[i];
+										}
+                                        setBoardDetail(arrayConcat);
                                     }}
                                     fnDeleteFile={(deletedFile) => {
                                         console.log("====>>> Delete deletedFile = ", deletedFile);

--- a/src/pages/inform/notice/EgovNoticeEdit.jsx
+++ b/src/pages/inform/notice/EgovNoticeEdit.jsx
@@ -211,7 +211,11 @@ function EgovNoticeEdit(props) {
                                 <EgovAttachFile
                                     fnChangeFile={(attachfile) => {
                                         console.log("====>>> Changed attachfile file = ", attachfile);
-                                        setBoardDetail({ ...boardDetail, file_1: attachfile });
+                                        const arrayConcat = { ...boardDetail}; // 기존 단일 파일 업로드에서 다중파일 객체 추가로 변환(아래 for문으로)
+										for ( let i = 0; i < attachfile.length; i++) {
+											arrayConcat[`file_${i}`] = attachfile[i];
+										}
+                                        setBoardDetail(arrayConcat);
                                     }}
                                     fnDeleteFile={(deletedFile) => {
                                         console.log("====>>> Delete deletedFile = ", deletedFile);


### PR DESCRIPTION
## 수정 사유 Reason for modification
- 기존 단일파일 업로드 부분을 멀티파일(다중파일) 업로드가 가능하도록 기능을 개선 하였습니다.
소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [ ] 버그수정 Bug fixes
- [X] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.
- EgovAttachFile.jsx : 첨부파일 컴포넌트에서 라인113 input file 부분을 multiple 속성 추가 및 라인59의 onChangeFileInput 함수에서 다중파일 배열객체로 변경 및 업로드 개수 제한하는 유효성 검사 코드 추가
- EgovNoticeEdit.jsx 포함 5개의 게시판형 페이지에서 단일파일 처리를 arrayConcat 변수로 다중파일 객체로 처리하는 코드 추가

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [ ] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [X] Chrome
- [ ] Firefox
- [X] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡쳐 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡쳐 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.
- 우선 [사이트관리] 메뉴의 [게시판생성관리] 에서 공지사항의 첨부파일가능파일숫자를 3개로 변경한다.(아래)
![image](https://user-images.githubusercontent.com/52336625/234485617-021eaa49-e16c-47e1-9edf-50c33786add7.png)
- 위 공지사항 첨부파일을 3개로 조정 후 공지사항 게시판에서 파일 3개를 선택 가능하고, 업로드 된 파일 중 1개를 삭제 한 후 화면과 제한 개수 이상의  첨부파일을 선택 할 경우 유효성 검사 창(아래 붉은색 영역) 까지 나온 화면(아래)
![image](https://user-images.githubusercontent.com/52336625/234486422-6aadb5d2-0f8e-4443-949c-84a9ff549f54.png)