### PR TITLE
useRef객체를 사용하여 페이지 마운트 된 후 ui.js를 로딩 하도록 소스를 수정

### DIFF
--- a/src/components/EgovError.jsx
+++ b/src/components/EgovError.jsx
@@ -12,9 +12,7 @@ function EgovError(prop) { // index.jsx 라우터에서 보내온 이전 페이�
     }
 
     const goBack = () => {
-      //에러페이지로 이동하면 헤더가 없어지기 때문에 에러 이전페이지로 돌아갈 때 로딩한 ui.js가 제대로 작동하지 않는다. 그래서, 이전 URL을 재 로딩하는 코드를 추가한다. 
-	  navigate(prop.prevUrl.pathname); // porp 속성 값을 이전 URL로 사용한다.
-      navigate(0, { replace: true });// 이전 URL을 현재 페이지 인식하고 재 로딩하는 코드.
+      navigate(-1, { replace: true });// 이전 URL을 현재 페이지 인식하고 재 로딩하는 코드.
     }
 
     return (

--- a/src/js/ui.js
+++ b/src/js/ui.js
@@ -1,34 +1,5 @@
-let init;
 
 export default function initPage() {
-	//모바일에서 관리자 메뉴가 동적으로 추가되었을 때 서브메뉴가 정상 작동되도록 코드 추가 : 2023.04.14(금) 김일국 추가
-	const sessionUser = sessionStorage.getItem('loginUser');
-    const sessionUserSe = JSON.parse(sessionUser)?.userSe;
-	if(sessionUserSe ==='USR'){
-	    // Mobile 서브메뉴 항목 클릭시 메뉴 닫기
-        document.querySelectorAll('.all_menu.Mobile .submenu a')
-			.forEach(el => el.addEventListener('click', () =>  {
-            	document.querySelector('.all_menu.Mobile').classList.add('closed');
-        }));
-        // 모바일 관리자 하위 메뉴 열고 닫기
-		const nodes = document.querySelectorAll('.all_menu.Mobile h3 a');
-		const last_submenu = nodes[nodes.length- 1];
-		last_submenu.addEventListener('click', (e) => {
-			e.preventDefault();
-			const el = e.target;
-			el.classList.toggle('active');
-			const submenu = el.parentElement.nextElementSibling;
-            if (submenu.matches('.closed')) {
-                submenu.style.height = submenu.scrollHeight + 'px';
-                submenu.classList.remove('closed');
-            } else {
-                submenu.classList.add('closed');
-                submenu.style.height = '';
-            }
-		});
-	}
-    if (init) return;
-    init = true;
 
     /* 전체메뉴 */
         // 웹

--- a/src/routes/index.jsx
+++ b/src/routes/index.jsx
@@ -67,20 +67,9 @@ import EgovAdminPasswordUpdate from 'pages/admin/manager/EgovAdminPasswordUpdate
 import * as EgovNet from 'api/egovFetch'; // jwt토큰 위조 검사 때문에 추가
 import initPage from 'js/ui';
 
-// 에러 페이지와 같은 상단(EgovHeader) 소스가 제외된 페이지에서 ui.js의 햄버거버튼 작동오류가 발생한다. 
-// 즉, ui.js가 작동되지 않아서 재 로딩 해야 한다. 그래서, useRef객체를 사용하여 이전 페이지 URL을 구하는 코드 추가(아래)
-const usePrevLocation = (location) => {
-	const prevLocRef = useRef(location);
-	useEffect(()=>{
-		prevLocRef.current = location;
-	},[location]);
-	return prevLocRef.current;
-}
-
 const RootRoutes = () => {
-  //useLocation객체를 이용하여 에러페이시 이동 전 location 객체를 저장하는 코드 추가(아래 2줄) */}
+  //useLocation객체를 이용하여 정규표현식을 사용한 /admin/~ 으로 시작하는 경로와 비교에 사용(아래 1줄) */}
   const location = useLocation();
-  const prevLocation = usePrevLocation(location);
 
   //리액트에서 사이트관리자에 접근하는 토큰값 위변조 방지용으로 서버에서 비교하는 함수 추가
   const jwtAuthentication = useCallback(() => {
@@ -126,8 +115,8 @@ const RootRoutes = () => {
 
   if(mounted) { // 인증 없이 시스템관리 URL로 접근할 때 렌더링 되는 것을 방지하는 조건추가. 
 	  return (
-	      <Routes> {/* 에러페지시 호출시 이전 prevUrl객체를 전송하는 코드 추가(아래) */}
-	        <Route path={URL.ERROR} element={<EgovError prevUrl={prevLocation} />} />
+	      <Routes>
+	        <Route path={URL.ERROR} element={<EgovError />} />
 	        <Route path="*" element={<SecondRoutes/>} />
 	      </Routes>
 	  )
@@ -138,9 +127,15 @@ const SecondRoutes = () => {
 
   const [loginVO, setLoginVO] = useState({});
 
+  //useRef객체를 사용하여 페이지 마운트 된 후 ui.js를 로딩 하도록 변경 코드 추가(아래)
+  const isMounted = useRef(false); // 아래 로그인 이동 부분이 2번 실행되지 않도록 즉, 마운트 될 때만 실행되도록 변수 생성
   useEffect(() => {
-    initPage();
-  });
+    if (!isMounted.current) { // 컴포넌트 최초 마운트 시 페이지 진입 전(렌더링 전) 실행
+		isMounted.current = true; // 이 값으로 true 일 때만 페이지를 렌더링이 되는 변수 사용.
+	}else{
+		initPage();
+	}
+  },[]);
   
   return (
     <>


### PR DESCRIPTION
## 수정 사유 Reason for modification
- index.jsx 파일에서 useRef객체를 사용하여 페이지 마운트 된 후 ui.js를 로딩 하도록 소스를 수정 하면,
- 로그인 전/후 ui.js 내용이 제대로 구동되지 않는 문제로 이전에 추가한 복잡한 코드를 단순화 시킬 수 있게된다.
- 즉, 단순한 코드 수정으로 로그인/로그아웃/에러페이지 발생 이후 모든 페이지에서 ui.js 메뉴스크립트가 정상작동된다.

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [ ] 버그수정 Bug fixes
- [X] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.
- index.jsx 파일 라인131 : 에러페이지(EgovError.jsx)용 prevUrl=prevLocation 속성변수 사용을 모두 제거 후 아래 핵심코드로 변경. 
```
//useRef객체를 사용하여 페이지 마운트 된 후 ui.js를 로딩 하도록 변경 코드 추가(아래)
  const isMounted = useRef(false); // 아래 로그인 이동 부분이 2번 실행되지 않도록 즉, 마운트 될 때만 실행되도록 변수 생성
  useEffect(() => {
    if (!isMounted.current) { // 컴포넌트 최초 마운트 시 페이지 진입 전(렌더링 전) 실행
		isMounted.current = true; // 이 값으로 true 일 때만 페이지를 렌더링이 되는 변수 사용.
	}else{
		initPage();
	}
  },[]);
```
- ui.js 파일 :  위 메뉴핵심코드 변경 이전에 추가한 [시스템관리 메뉴용] if조건문과 기존 let init; 로 구현한 소스 제거.
- EgovError.jsx 파일 : 위 메뉴핵심코드 변경 이전에 추가한 이전페이지 속성변수를 사용한 페이지 소스 원상복구.
- **EgovError.jsx 파일 라인4번에** function EgovError(**prop**) { //**prop 속성을 사용하지 않기 때문에 삭제해야 하는데, 이부분 삭제 못했습니다. 삭제 부탁드립니다.^^**
## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [ ] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [X] Chrome
- [ ] Firefox
- [X] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡쳐 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡쳐 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.
- 수정 후 : 로그인/로그아웃/에러페이지 발생 이후에도 모두 ui.js 가 정상작동하고, 에러페이지에서 이전페이지로 이동 시 화면깜박임도 없어지고 정상화되었다.(아래)
![image](https://user-images.githubusercontent.com/52336625/235045979-eca333e4-58ef-44b4-ac71-a641dcf86e66.png)