### PR TITLE
refactor: storage 관련  util로 분리

### DIFF
--- a/src/api/egovFetch.js
+++ b/src/api/egovFetch.js
@@ -2,6 +2,7 @@ import { SERVER_URL } from '../config';
 
 import URL from 'constants/url';
 import CODE from 'constants/code';
+import { getSessionItem, setSessionItem } from 'utils/storage';
 
 export function requestFetch(url, requestOptions, handler, errorHandler) {
     console.groupCollapsed("requestFetch");
@@ -9,9 +10,9 @@ export function requestFetch(url, requestOptions, handler, errorHandler) {
     console.log("requestFetch [requestOption] : ", requestOptions);
 
     // Login 했을경우 JWT 설정
-    const sessionUser = sessionStorage.getItem('loginUser');
-    const sessionUserId = JSON.parse(sessionUser)?.id || null;
-    const jToken = sessionStorage.getItem('jToken') || null;
+    const sessionUser = getSessionItem('loginUser');
+    const sessionUserId = sessionUser?.id || null;
+    const jToken = getSessionItem('jToken');
     if(sessionUserId != null && sessionUserId !== undefined){
         if( !requestOptions['headers'] ) requestOptions['headers']={}
         if( !requestOptions['headers']['Authorization'] ) requestOptions['headers']['Authorization']=null;
@@ -37,7 +38,7 @@ export function requestFetch(url, requestOptions, handler, errorHandler) {
         .then((resp) => {
             if (Number(resp.resultCode) === Number(CODE.RCV_ERROR_AUTH)) {
                 alert("Login Alert"); //index.jsx라우터파일에 jwtAuthentication 함수로 공통 인증을 사용하는 코드 추가로 alert 원상복구
-                sessionStorage.setItem('loginUser', JSON.stringify({"id":""}));
+                setSessionItem('loginUser', {"id":""});
                 window.location.href = URL.LOGIN;
                 return false;
             } else {

--- a/src/components/EgovHeader.jsx
+++ b/src/components/EgovHeader.jsx
@@ -5,15 +5,16 @@ import * as EgovNet from 'api/egovFetch';
 
 import URL from 'constants/url';
 import CODE from 'constants/code';
+import { getSessionItem, setSessionItem } from 'utils/storage';
 
 function EgovHeader({ loginUser, onChangeLogin }) {
     console.group("EgovHeader");
     console.log("[Start] EgovHeader ------------------------------");
 
-    const sessionUser = sessionStorage.getItem('loginUser');
-    const sessionUserId = JSON.parse(sessionUser)?.id;
-    const sessionUserName = JSON.parse(sessionUser)?.name;
-    const sessionUserSe = JSON.parse(sessionUser)?.userSe;
+    const sessionUser = getSessionItem('loginUser');
+    const sessionUserId = sessionUser?.id;
+    const sessionUserName = sessionUser?.name;
+    const sessionUserSe = sessionUser?.userSe;
 
     const navigate = useNavigate();
 
@@ -38,8 +39,8 @@ function EgovHeader({ loginUser, onChangeLogin }) {
                 console.log("===>>> logout resp= ", resp);
                 if (parseInt(resp.resultCode) === parseInt(CODE.RCV_SUCCESS)) {
                     onChangeLogin({ loginVO: {} });
-                    sessionStorage.setItem('loginUser', JSON.stringify({"id":""}));
-                    sessionStorage.setItem('jToken', null);
+                    setSessionItem('loginUser', {"id":""});
+                    setSessionItem('jToken', null);
                     window.alert("로그아웃되었습니다!");
                     navigate(URL.MAIN);
 					// PC와 Mobile 열린메뉴 닫기: 2023.04.13(목) 김일국 추가

--- a/src/pages/login/EgovLoginContent.jsx
+++ b/src/pages/login/EgovLoginContent.jsx
@@ -4,6 +4,7 @@ import * as EgovNet from 'api/egovFetch';
 
 import URL from 'constants/url';
 import CODE from 'constants/code';
+import { getLocalItem, setLocalItem, setSessionItem } from 'utils/storage';
 
 function EgovLoginContent(props) {
     console.group("EgovLoginContent");
@@ -24,38 +25,36 @@ function EgovLoginContent(props) {
 
     const KEY_ID = "KEY_ID";
     const KEY_SAVE_ID_FLAG = "KEY_SAVE_ID_FLAG";
-
+    
     const handleSaveIDFlag = () => {
-        localStorage.setItem(KEY_SAVE_ID_FLAG, !saveIDFlag);
+        setLocalItem(KEY_SAVE_ID_FLAG, !saveIDFlag)
         setSaveIDFlag(!saveIDFlag);
     };
-
-    let idFlag;
-        try {
-            idFlag = JSON.parse(localStorage.getItem(KEY_SAVE_ID_FLAG));
-        }
-        catch(err) {
-            idFlag = null;
-        } 
-
+    
     useEffect(() => {
-
+        let idFlag = getLocalItem(KEY_SAVE_ID_FLAG);
         if (idFlag === null) {
             setSaveIDFlag(false);
 			// eslint-disable-next-line react-hooks/exhaustive-deps
             idFlag = false;
+        } else {
+            setSaveIDFlag(idFlag);
         }
-        if (idFlag !== null) setSaveIDFlag(idFlag);
+
         if (idFlag === false) {
-            localStorage.setItem(KEY_ID, "");
+            setLocalItem(KEY_ID, "");
             checkRef.current.className = "f_chk"
         } else {
             checkRef.current.className = "f_chk on"
         };
-      
-        let data = localStorage.getItem(KEY_ID);
-        if (data !== null) setUserInfo({ ...userInfo, id: data });
-      }, [idFlag]);
+    }, []);
+
+    useEffect(() => {
+        let data = getLocalItem(KEY_ID);
+        if (data !== null) {
+            setUserInfo({ id: data, password: 'default', userSe: 'USR' });
+        }
+    }, []);
 
     const submitFormHandler = (e) => {
         console.log("EgovLoginContent submitFormHandler()");
@@ -74,15 +73,15 @@ function EgovLoginContent(props) {
             requestOptions,
             (resp) => {
                 let resultVO = resp.resultVO;
-                let jToken = resp?.jToken
+                let jToken = resp?.jToken || null;
 
-                sessionStorage.setItem('jToken', jToken);
+                setSessionItem('jToken', jToken);
 
                 if (Number(resp.resultCode) === Number(CODE.RCV_SUCCESS)) {
                     setLoginVO(resultVO);
-                    sessionStorage.setItem('loginUser', JSON.stringify(resultVO));
+                    setSessionItem('loginUser', resultVO);
                     props.onChangeLogin(resultVO);
-                    if (saveIDFlag) localStorage.setItem(KEY_ID, resultVO?.id);
+                    if (saveIDFlag) setLocalItem(KEY_ID, resultVO?.id);
                     navigate(URL.MAIN);
                     // PC와 Mobile 열린메뉴 닫기
                     document.querySelector('.all_menu.WEB').classList.add('closed');

--- a/src/utils/storage.js
+++ b/src/utils/storage.js
@@ -1,0 +1,38 @@
+function getItem(storage, key) {
+    const jsonStr = storage.getItem(key);
+    if (!jsonStr) return null;
+    return JSON.parse(jsonStr);
+}
+
+function setItem(storage, key, value) {
+    const str = (value === undefined) ? null : value;
+    storage.setItem(key, JSON.stringify(str));
+}
+
+function removeItem(storage, key) {
+    storage.removeItem(key);
+}
+
+export function getLocalItem(key) {
+    return getItem(localStorage, key);
+}
+
+export function setLocalItem(key, value) {
+    setItem(localStorage, key, value);
+}
+
+export function removeLocalItem(key) {
+    removeItem(localStorage, key);
+}
+
+export function getSessionItem(key) {
+    return getItem(sessionStorage, key);
+}
+
+export function setSessionItem(key, value) {
+    setItem(sessionStorage, key, value);
+}
+
+export function removeSessionItem(key) {
+    removeItem(sessionStorage, key);
+}


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [ ] 버그수정 Bug fixes
- [x] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

localStorage와 sessionStorage를 set/get 하는 과정에서 필요에 따라 매번 JSON.parse를 해야하는데 중복코드 및 실수가 발생할 수 있어 util로 분리하였습니다.

또한 undefined를 value로 호출 시, null로 변환되어 저장되도록 하였습니다. 
이유는 기본적으로 storage는 string이 저장되며, json 객체를 저장 시 JSON.stringify를 사용하여 string으로 변환 후 저장을 하는 방법을 사용하는데요. 이 과정에서 undefined는 null로 변환이 됩니다. 동일한 패턴을 사용하여 undefined 값을 저장하려고 하면 null로 변환하였습니다.

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [ ] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [X] Chrome
- [ ] Firefox
- [ ] Edge
- [X] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡쳐 영상 Test screenshots or captured video
BEFORE
<img width="1327" alt="image" src="https://github.com/eGovFramework/egovframe-template-simple-react/assets/36249859/fe4e914f-366e-44ba-8cd7-c0e423df8cc9">

AFTER
<img width="1242" alt="image" src="https://github.com/eGovFramework/egovframe-template-simple-react/assets/36249859/dcb7a2ef-06bd-4fd4-bf75-5098b4cb4bc6">
