### PR TITLE
select 태그 우측 ::after 영역이 클릭 시 동작하도록 수정

### DIFF
--- a/src/css/component.css
+++ b/src/css/component.css
@@ -261,7 +261,7 @@ select::-ms-expand {display:none;}
 .f_rdo input {position: absolute; top: -9999px;}
 
 .f_select {display: inline-block; position: relative; height: 46px; border: 0; border-radius: 5px; background: #f7f7f7;}
-.f_select::after {content: ""; display: block; position: absolute; right: 20px; top: 50%; transform: translateY(-50%); width: 15px; height: 9px; background: url(css/images/ico_arrow_gray_15x9.png) no-repeat;}
+.f_select::after {content: ""; display: block; position: absolute; right: 20px; top: 50%; transform: translateY(-50%); width: 15px; height: 9px; background: url(css/images/ico_arrow_gray_15x9.png) no-repeat; pointer-events: none;}
 .f_select select {width: 100%; height: 100%; padding: 0 40px 0 20px; border: 0; color: #222; font-size: 16px; background: transparent;}
 
 .f_input {height: 46px; padding: 0 20px; border: 0; border-radius: 5px; color: #222; font-size: 16px; background: #f7f7f7;}


### PR DESCRIPTION
## 수정 사유 Reason for modification

관리자 -> 사이트관리 -> 게시판생성관리 -> 등록 하는 경우 게시판 유형을 select 할 수 있습니다.
이 때 select 태그 위에 ::after가 자리를 차지하여 클릭이 동작하지 않는 현상이 일어나서
사용자 편의를 위하여 ::after를 클릭하여도 select가 동작하도록 수정하였습니다.

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [ ] 버그수정 Bug fixes
- [X] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.

src - css - component.css 파일 264 라인 .f_select::after 속성에 pointer-events: none; 항목을 추가하였습니다.

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [ ] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [X] Chrome
- [ ] Firefox
- [X] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡처 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.

* 수정 전(빨간 네모 안 v 영역을 클릭하면 동작하지 않습니다.)
![pl1](https://github.com/user-attachments/assets/2cdd8a8e-bbd8-46fe-ac1d-b4f7324d4e20)

* 수정 후
![pl2](https://github.com/user-attachments/assets/a5184c54-21a0-48f8-99f5-65bac9891d10)

