### PR TITLE
고객지원 매뉴 하위 서비스신청 상세페이지 고객지원 타이틀 여백 수정

### DIFF
--- a/src/constants/url.js
+++ b/src/constants/url.js
@@ -63,7 +63,7 @@ const URL = {
     ADMIN_USAGE_CREATE          : "/admin/usage/create", // 사이트관리/게시판사용관리 등록
     ADMIN_USAGE_MODIFY          : "/admin/usage/modify", // 사이트관리/게시판사용관리 상세/수정
 
-    ADMIN_NOTICE                : "/admin/notice/", // 사이트관리/공지사항관리 목록
+    ADMIN_NOTICE                : "/admin/notice", // 사이트관리/공지사항관리 목록
     ADMIN_NOTICE_DETAIL         : "/admin/notice/detail", // 사이트관리/공지사항관리 상세
     ADMIN_NOTICE_CREATE         : "/admin/notice/create", // 사이트관리/공지사항관리 등록
     ADMIN_NOTICE_MODIFY         : "/admin/notice/modify", // 사이트관리/공지사항관리 수정
@@ -75,11 +75,11 @@ const URL = {
     ADMIN_GALLERY_MODIFY        : "/admin/gallery/modify", // 사이트관리/사이트갤러리관리 수정
     ADMIN_GALLERY_REPLY         : "/admin/gallery/reply", // 사이트관리/사이트갤러리관리 답글 등록
     
-	ADMIN_MANAGER               : "/admin/manager/", // 사이트관리/사이트관리자 암호변경 기능
-	ADMIN_MEMBERS               : "/admin/members/", // 사이트관리/회원관리 목록기능
-	ADMIN_MEMBERS_DETAIL          : "/admin/members/detail", // 사이트관리/회원관리 상세
-    ADMIN_MEMBERS_CREATE          : "/admin/members/create", // 사이트관리/회원관리 등록
-    ADMIN_MEMBERS_MODIFY          : "/admin/members/modify", // 사이트관리/회원관리 상세/수정
+	ADMIN_MANAGER               : "/admin/manager", // 사이트관리/사이트관리자 암호변경 기능
+	ADMIN_MEMBERS               : "/admin/members", // 사이트관리/회원관리 목록기능
+	ADMIN_MEMBERS_DETAIL        : "/admin/members/detail", // 사이트관리/회원관리 상세
+    ADMIN_MEMBERS_CREATE        : "/admin/members/create", // 사이트관리/회원관리 등록
+    ADMIN_MEMBERS_MODIFY        : "/admin/members/modify", // 사이트관리/회원관리 상세/수정
     
     //MYPAGE
     MYPAGE_MODIFY      			: "/mypage/modify", // 고객지원/마이페이지/회원 수정

--- a/src/constants/url.js
+++ b/src/constants/url.js
@@ -74,13 +74,13 @@ const URL = {
     ADMIN_GALLERY_CREATE        : "/admin/gallery/create", // 사이트관리/사이트갤러리관리 등록
     ADMIN_GALLERY_MODIFY        : "/admin/gallery/modify", // 사이트관리/사이트갤러리관리 수정
     ADMIN_GALLERY_REPLY         : "/admin/gallery/reply", // 사이트관리/사이트갤러리관리 답글 등록
-    
-	ADMIN_MANAGER               : "/admin/manager", // 사이트관리/사이트관리자 암호변경 기능
-	ADMIN_MEMBERS               : "/admin/members", // 사이트관리/회원관리 목록기능
-	ADMIN_MEMBERS_DETAIL        : "/admin/members/detail", // 사이트관리/회원관리 상세
+
+    ADMIN_MANAGER               : "/admin/manager", // 사이트관리/사이트관리자 암호변경 기능
+    ADMIN_MEMBERS               : "/admin/members", // 사이트관리/회원관리 목록기능
+    ADMIN_MEMBERS_DETAIL        : "/admin/members/detail", // 사이트관리/회원관리 상세
     ADMIN_MEMBERS_CREATE        : "/admin/members/create", // 사이트관리/회원관리 등록
     ADMIN_MEMBERS_MODIFY        : "/admin/members/modify", // 사이트관리/회원관리 상세/수정
-    
+
     //MYPAGE
     MYPAGE_MODIFY      			: "/mypage/modify", // 고객지원/마이페이지/회원 수정
     MYPAGE_CREATE       		: "/mypage/create", // 고객지원/마이페이지/회원 등록

--- a/src/css/component.css
+++ b/src/css/component.css
@@ -294,6 +294,7 @@ select::-ms-expand {display:none;}
 
 .tit_5 {color: #222; font-size: 26px; font-weight: 700;}
 
+.tit_6 {color: #222; font-size: 48px; font-weight: 500; line-height: 44px; letter-spacing: -2px;}
 
 /* Text */
 .txt_1 {color: #666; font-size: 20px; line-height: 30px;}

--- a/src/css/layout.css
+++ b/src/css/layout.css
@@ -100,6 +100,7 @@ body {min-width: 1400px;}
 
 /* Space */
 .contents .tit_3:first-child {margin-top: -2px;}
+.contents .tit_6:first-child {margin-top: 2px;}
 
 .condition + .board_list {margin-top: 50px;}
 .condition + .calendar_list {margin-top: 50px;}
@@ -117,6 +118,8 @@ body {min-width: 1400px;}
 
 .tit_5 + .msg_1 {margin-top: 24px;}
 .tit_5 + .pds_des {margin-top: 14px;}
+
+.tit_6 + .txt_1 {margin-top: 33px;}
 
 .txt_1 + .tit_4 {margin-top: 64px;}
 

--- a/src/pages/support/apply/EgovSupportApply.jsx
+++ b/src/pages/support/apply/EgovSupportApply.jsx
@@ -24,7 +24,7 @@ function EgovSupportApply() {
                     <div className="contents SITE_INTRO" id="contents">
                         {/* <!-- 본문 --> */}
 
-                        <h1 className="tit_3">고객지원</h1>
+                        <h1 className="tit_6">고객지원</h1>
 
                         <p className="txt_1">프레임워크 경량환경의 원하시는 서비스를 신청하실 수 있습니다.</p>
                         


### PR DESCRIPTION
## 수정 사유 Reason for modification

고객지원 매뉴 진입 후 왼쪽 고객지원 left 네비 매뉴
1. 자료실을 클릭하고 서비스신청 페이지로 이동
2. 묻고답하기를 클릭하고 서비스신청 페이지로 이동
하는 경우 고객지원 타이틀의 높이가 달라서 일관성을 유지하기 위하여
수정하였습니다.
(다른 매뉴들은 tit_1 혹은 tit_3만 사용하는데 고객지원 매뉴만 같이 사용하여 발생)

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [ ] 버그수정 Bug fixes
- [X] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.

src - css - component.css 파일에 .tit_6 추가
src - css - layout.css 파일에 .tit_6 + .txt_1 추가
src\pages\support\apply\EgovSupportApply.jsx 파일 27 라인 tit_3 -> tit_6로 수정

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [ ] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [X] Chrome
- [ ] Firefox
- [X] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡처 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.


![b1](https://github.com/user-attachments/assets/e45c3702-2002-48c1-a8cf-9f00733e6068)

![b2](https://github.com/user-attachments/assets/bdfe0b63-b905-4541-9f66-b5286998da30)

-> 스크린샷으로 차이점을 알기 한계가 있어 직접 고객지원 매뉴 자료실 -> 서비스신청, 묻고답하기 -> 서비스신청 이동 시 차이점을 확인 할 수 있습니다.