### PR TITLE
Feat(admin.notice) : 어드민 공지사항 게시글 삭제 시 atchFileId 포함하여 API 호출하도록 수정

### DIFF
--- a/src/pages/admin/gallery/EgovAdminGalleryDetail.jsx
+++ b/src/pages/admin/gallery/EgovAdminGalleryDetail.jsx
@@ -43,7 +43,7 @@ function EgovAdminGalleryDetail(props) {
     });
   };
 
-  const onClickDeleteBoardArticle = (bbsId, nttId) => {
+  const onClickDeleteBoardArticle = (bbsId, nttId, atchFileId) => {
     const deleteBoardURL = `/board/${bbsId}/${nttId}`;
 
     const requestOptions = {
@@ -51,6 +51,7 @@ function EgovAdminGalleryDetail(props) {
       headers: {
         "Content-type": "application/json",
       },
+      body: JSON.stringify({ atchFileId: atchFileId })
     };
 
     EgovNet.requestFetch(deleteBoardURL, requestOptions, (resp) => {
@@ -168,7 +169,8 @@ function EgovAdminGalleryDetail(props) {
                         e.preventDefault();
                         onClickDeleteBoardArticle(
                           boardDetail.bbsId,
-                          boardDetail.nttId
+                          boardDetail.nttId,
+                          boardDetail.atchFileId
                         );
                       }}
                     >

--- a/src/pages/admin/notice/EgovAdminNoticeDetail.jsx
+++ b/src/pages/admin/notice/EgovAdminNoticeDetail.jsx
@@ -43,13 +43,14 @@ function EgovAdminNoticeDetail(props) {
   };
 
   const onClickDeleteBoardArticle = (bbsId, nttId, atchFileId) => {
-    const deleteBoardURL = `/board/${bbsId}/${nttId}/${atchFileId}`;
+    const deleteBoardURL = `/board/${bbsId}/${nttId}`;
 
     const requestOptions = {
       method: "PATCH",
       headers: {
         "Content-type": "application/json",
       },
+      body: JSON.stringify({ atchFileId: atchFileId })
     };
 
     EgovNet.requestFetch(deleteBoardURL, requestOptions, (resp) => {

--- a/src/pages/admin/notice/EgovAdminNoticeDetail.jsx
+++ b/src/pages/admin/notice/EgovAdminNoticeDetail.jsx
@@ -42,8 +42,8 @@ function EgovAdminNoticeDetail(props) {
     });
   };
 
-  const onClickDeleteBoardArticle = (bbsId, nttId) => {
-    const deleteBoardURL = `/board/${bbsId}/${nttId}`;
+  const onClickDeleteBoardArticle = (bbsId, nttId, atchFileId) => {
+    const deleteBoardURL = `/board/${bbsId}/${nttId}/${atchFileId}`;
 
     const requestOptions = {
       method: "PATCH",
@@ -163,7 +163,8 @@ function EgovAdminNoticeDetail(props) {
                         e.preventDefault();
                         onClickDeleteBoardArticle(
                           boardDetail.bbsId,
-                          boardDetail.nttId
+                          boardDetail.nttId,
+                          boardDetail.atchFileId
                         );
                       }}
                     >

--- a/src/pages/inform/gallery/EgovGalleryDetail.jsx
+++ b/src/pages/inform/gallery/EgovGalleryDetail.jsx
@@ -50,7 +50,7 @@ function EgovGalleryDetail(props) {
     });
   };
 
-  const onClickDeleteBoardArticle = (bbsId, nttId) => {
+  const onClickDeleteBoardArticle = (bbsId, nttId, atchFileId) => {
     const deleteBoardURL = `/board/${bbsId}/${nttId}`;
 
     const requestOptions = {
@@ -58,6 +58,7 @@ function EgovGalleryDetail(props) {
       headers: {
         "Content-type": "application/json",
       },
+      body: JSON.stringify({ atchFileId: atchFileId })
     };
 
     EgovNet.requestFetch(deleteBoardURL, requestOptions, (resp) => {
@@ -177,7 +178,8 @@ function EgovGalleryDetail(props) {
                           e.preventDefault();
                           onClickDeleteBoardArticle(
                             boardDetail.bbsId,
-                            boardDetail.nttId
+                            boardDetail.nttId,
+                            boardDetail.atchFileId
                           );
                         }}
                       >

--- a/src/pages/inform/notice/EgovNoticeDetail.jsx
+++ b/src/pages/inform/notice/EgovNoticeDetail.jsx
@@ -48,7 +48,7 @@ function EgovNoticeDetail(props) {
     });
   };
 
-  const onClickDeleteBoardArticle = (bbsId, nttId) => {
+  const onClickDeleteBoardArticle = (bbsId, nttId, atchFileId) => {
     const deleteBoardURL = `/board/${bbsId}/${nttId}`;
 
     const requestOptions = {
@@ -56,6 +56,7 @@ function EgovNoticeDetail(props) {
       headers: {
         "Content-type": "application/json",
       },
+      body: JSON.stringify({ atchFileId: atchFileId })
     };
 
     EgovNet.requestFetch(deleteBoardURL, requestOptions, (resp) => {
@@ -170,7 +171,8 @@ function EgovNoticeDetail(props) {
                           e.preventDefault();
                           onClickDeleteBoardArticle(
                             boardDetail.bbsId,
-                            boardDetail.nttId
+                            boardDetail.nttId,
+                            boardDetail.atchFileId
                           );
                         }}
                       >


### PR DESCRIPTION
## 수정 사유 Reason for modification
- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source
기존 코드에서 게시글 삭제 처리를 위한 atchFileId를 삭제 API로 전달하지 않아 발생하던 문제를 해결하기 위한 PR입니다.
삭제버튼 클릭 시 atchFileId를 onClickDeleteBoardArticle에 전달하여 /board/${bbsId}/${nttId}/${atchFileId} 형태로 API를 호출할 수 있도록 수정하였습니다.

해당 이슈는 https://github.com/eGovFramework/egovframe-template-simple-backend/pull/80 에서 같이 수정되었습니다.

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [ ] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser
테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.
- [X] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

