### PR TITLE
Refactor(board): textarea 입력 이벤트를 onChange에서 onBlur로 변경

### DIFF
--- a/src/hooks/useDebounce.jsx
+++ b/src/hooks/useDebounce.jsx
@@ -1,0 +1,60 @@
+import { useCallback, useEffect, useRef } from "react";
+
+/** 
+ * 일정 시간(delay) 동안 입력이 없을 때만 콜백 함수를 실행하는 디바운스 훅입니다.
+ * 
+ * @param {Function} callback - 디바운싱할 콜백 함수
+ * @param {number} delay - 디바운싱 지연 시간 (기본값 300ms)
+ * @returns {Function} - 디바운싱된 콜백 함수
+*/
+const useDebounce = (callback, delay = 300) => {
+  const timeoutRef = useRef(null);
+
+  const debouncedCallback = useCallback(
+    (...args) => {
+      // 이전 타이머가 존재하면 타이머 정리
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+
+      // 새로운 타이머 설정 (delay만큼 지연 후 콜백 실행)
+      timeoutRef.current = setTimeout(() => {
+        callback(...args);
+      }, delay);
+    },
+    [callback, delay]
+  );
+
+  // 컴포넌트 언마운트 시 타이머 정리
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+    };
+  }, []);
+
+  return debouncedCallback;
+};
+
+/**
+ * useDebouncedInput 훅은 입력 필드의 변경 사항을 디바운싱하여 상태를 업데이트합니다.
+ * 
+ * @param {Function} setState - 상태 변경 함수
+ * @param {number} delay - 디바운싱 지연 시간 (기본값 300ms)
+ * @return {Function} - 디바운싱이 적용된 입력 핸들러 함수
+ */
+export const useDebouncedInput = (setState, delay = 300) => {
+  const debouncedSetState = useDebounce((field, value) => {
+    setState((prev) => ({ ...prev, [field]: value }));
+  }, delay);
+
+  const handleInputChange = useCallback(
+    (field, value) => {
+      debouncedSetState(field, value);
+    },
+    [debouncedSetState]
+  );
+
+  return handleInputChange;
+};

--- a/src/pages/admin/board/EgovAdminBoardEdit.jsx
+++ b/src/pages/admin/board/EgovAdminBoardEdit.jsx
@@ -4,6 +4,7 @@ import { Link, useNavigate, useLocation } from "react-router-dom";
 import * as EgovNet from "@/api/egovFetch";
 import URL from "@/constants/url";
 import CODE from "@/constants/code";
+import { useDebouncedInput } from "@/hooks/useDebounce";
 
 import { default as EgovLeftNav } from "@/components/leftmenu/EgovLeftNavAdmin";
 import EgovRadioButtonGroup from "@/components/EgovRadioButtonGroup";
@@ -47,6 +48,7 @@ function EgovAdminBoardEdit(props) {
 
   const [modeInfo, setModeInfo] = useState({ mode: props.mode });
   const [boardDetail, setBoardDetail] = useState({});
+  const handleInputChange = useDebouncedInput(setBoardDetail, 300);
 
   const initMode = () => {
     switch (props.mode) {
@@ -294,7 +296,7 @@ function EgovAdminBoardEdit(props) {
                     id="bbsNm"
                     placeholder=""
                     defaultValue={boardDetail.bbsNm}
-                    onBlur={(e) =>
+                    onChange={(e) =>
                       setBoardDetail({ ...boardDetail, bbsNm: e.target.value })
                     }
                     ref={(el) => (checkRef.current[0] = el)}
@@ -315,12 +317,7 @@ function EgovAdminBoardEdit(props) {
                     rows="10"
                     placeholder=""
                     defaultValue={boardDetail.bbsIntrcn}
-                    onBlur={(e) =>
-                      setBoardDetail({
-                        ...boardDetail,
-                        bbsIntrcn: e.target.value,
-                      })
-                    }
+                    onChange={(e) => handleInputChange("bbsIntrcn", e.target.value)}
                     ref={(el) => (checkRef.current[1] = el)}
                   ></textarea>
                 </dd>

--- a/src/pages/admin/gallery/EgovAdminGalleryEdit.jsx
+++ b/src/pages/admin/gallery/EgovAdminGalleryEdit.jsx
@@ -10,6 +10,7 @@ import { GALLERY_BBS_ID } from "@/config";
 import { default as EgovLeftNav } from "@/components/leftmenu/EgovLeftNavAdmin";
 import EgovAttachFile from "@/components/EgovAttachFile";
 import bbsFormVaildator from "@/utils/bbsFormVaildator";
+import { useDebouncedInput } from "@/hooks/useDebounce";
 
 function EgovAdminGalleryEdit(props) {
   console.group("EgovAdminGalleryEdit");
@@ -27,6 +28,8 @@ function EgovAdminGalleryEdit(props) {
   const [masterBoard, setMasterBoard] = useState({});
   const [boardDetail, setBoardDetail] = useState({ nttSj: "", nttCn: "" });
   const [boardAttachFiles, setBoardAttachFiles] = useState();
+
+  const handleInputChange = useDebouncedInput(setBoardDetail, 300);
 
   const intMode = () => {
     switch (props.mode) {
@@ -222,9 +225,7 @@ function EgovAdminGalleryEdit(props) {
                     rows="10"
                     placeholder=""
                     defaultValue={boardDetail.nttCn}
-                    onBlur={(e) =>
-                      setBoardDetail({ ...boardDetail, nttCn: e.target.value })
-                    }
+                    onChange={(e) => handleInputChange("nttCn", e.target.value)}
                   ></textarea>
                 </dd>
               </dl>

--- a/src/pages/admin/notice/EgovAdminNoticeEdit.jsx
+++ b/src/pages/admin/notice/EgovAdminNoticeEdit.jsx
@@ -11,6 +11,8 @@ import { default as EgovLeftNav } from "@/components/leftmenu/EgovLeftNavAdmin";
 import EgovAttachFile from "@/components/EgovAttachFile";
 import bbsFormVaildator from "@/utils/bbsFormVaildator";
 
+import { useDebouncedInput } from "@/hooks/useDebounce";
+
 function EgovAdminNoticeEdit(props) {
   console.group("EgovAdminNoticeEdit");
   console.log("------------------------------");
@@ -27,6 +29,8 @@ function EgovAdminNoticeEdit(props) {
   const [masterBoard, setMasterBoard] = useState({});
   const [boardDetail, setBoardDetail] = useState({ nttSj: "", nttCn: "" });
   const [boardAttachFiles, setBoardAttachFiles] = useState();
+
+  const handleInputChange = useDebouncedInput(setBoardDetail, 300);
 
   const intMode = () => {
     switch (props.mode) {
@@ -200,7 +204,7 @@ function EgovAdminNoticeEdit(props) {
                     name="nttSj"
                     type="text"
                     defaultValue={boardDetail.nttSj}
-                    onBlur={(e) =>
+                    onChange={(e) =>
                       setBoardDetail({ ...boardDetail, nttSj: e.target.value })
                     }
                     maxLength="60"
@@ -222,9 +226,7 @@ function EgovAdminNoticeEdit(props) {
                     rows="10"
                     placeholder=""
                     defaultValue={boardDetail.nttCn}
-                    onBlur={(e) =>
-                      setBoardDetail({ ...boardDetail, nttCn: e.target.value })
-                    }
+                    onChange={(e) => handleInputChange("nttCn", e.target.value)}
                   ></textarea>
                 </dd>
               </dl>

--- a/src/pages/admin/schedule/EgovAdminScheduleEdit.jsx
+++ b/src/pages/admin/schedule/EgovAdminScheduleEdit.jsx
@@ -9,6 +9,7 @@ import CODE from "@/constants/code";
 import { default as EgovLeftNav } from "@/components/leftmenu/EgovLeftNavAdmin";
 import EgovAttachFile from "@/components/EgovAttachFile";
 import EgovRadioButtonGroup from "@/components/EgovRadioButtonGroup";
+import { useDebouncedInput } from "@/hooks/useDebounce";
 
 import "react-datepicker/dist/react-datepicker.css";
 
@@ -42,6 +43,8 @@ function EgovAdminScheduleEdit(props) {
   const [schdulBgndeMM, setSchdulBgndeMM] = useState();
   const [schdulEnddeHH, setSchdulEnddeHH] = useState();
   const [schdulEnddeMM, setSchdulEnddeMM] = useState();
+
+  const handleInputChange = useDebouncedInput(setScheduleDetail, 300);
 
   const initMode = () => {
     switch (props.mode) {
@@ -343,12 +346,7 @@ function EgovAdminScheduleEdit(props) {
                     rows="10"
                     placeholder="일정내용"
                     defaultValue={scheduleDetail.schdulCn}
-                    onBlur={(e) =>
-                      setScheduleDetail({
-                        ...scheduleDetail,
-                        schdulCn: e.target.value,
-                      })
-                    }
+                    onChange={(e) => handleInputChange("schdulCn", e.target.value)}
                   ></textarea>
                 </dd>
               </dl>

--- a/src/pages/inform/gallery/EgovGalleryEdit.jsx
+++ b/src/pages/inform/gallery/EgovGalleryEdit.jsx
@@ -11,6 +11,7 @@ import { default as EgovLeftNav } from "@/components/leftmenu/EgovLeftNavInform"
 import EgovAttachFile from "@/components/EgovAttachFile";
 import bbsFormVaildator from "@/utils/bbsFormVaildator";
 import { getSessionItem } from "@/utils/storage";
+import { useDebouncedInput } from "@/hooks/useDebounce";
 
 function EgovGalleryEdit(props) {
   console.group("EgovGalleryEdit");
@@ -31,6 +32,8 @@ function EgovGalleryEdit(props) {
   const [masterBoard, setMasterBoard] = useState({});
   const [boardDetail, setBoardDetail] = useState({ nttSj: "", nttCn: "" });
   const [boardAttachFiles, setBoardAttachFiles] = useState();
+
+  const handleInputChange = useDebouncedInput(setBoardDetail, 300);
 
   const intMode = () => {
     switch (props.mode) {
@@ -226,9 +229,7 @@ function EgovGalleryEdit(props) {
                     rows="10"
                     placeholder=""
                     defaultValue={boardDetail.nttCn}
-                    onBlur={(e) =>
-                      setBoardDetail({ ...boardDetail, nttCn: e.target.value })
-                    }
+                    onChange={(e) => handleInputChange("nttCn", e.target.value)}
                   ></textarea>
                 </dd>
               </dl>

--- a/src/pages/inform/notice/EgovNoticeEdit.jsx
+++ b/src/pages/inform/notice/EgovNoticeEdit.jsx
@@ -11,6 +11,7 @@ import { default as EgovLeftNav } from "@/components/leftmenu/EgovLeftNavInform"
 import EgovAttachFile from "@/components/EgovAttachFile";
 import bbsFormVaildator from "@/utils/bbsFormVaildator";
 import { getSessionItem } from "@/utils/storage";
+import { useDebouncedInput } from "@/hooks/useDebounce";
 
 function EgovNoticeEdit(props) {
   console.group("EgovNoticeEdit");
@@ -31,6 +32,8 @@ function EgovNoticeEdit(props) {
   const [masterBoard, setMasterBoard] = useState({});
   const [boardDetail, setBoardDetail] = useState({ nttSj: "", nttCn: "" });
   const [boardAttachFiles, setBoardAttachFiles] = useState();
+
+  const handleInputChange = useDebouncedInput(setBoardDetail, 300);
 
   const initMode = () => {
     switch (props.mode) {
@@ -226,9 +229,7 @@ function EgovNoticeEdit(props) {
                     rows="10"
                     placeholder=""
                     defaultValue={boardDetail.nttCn}
-                    onBlur={(e) =>
-                      setBoardDetail({ ...boardDetail, nttCn: e.target.value })
-                    }
+                    onChange={(e) => handleInputChange("nttCn", e.target.value)}
                   ></textarea>
                 </dd>
               </dl>


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [ ] 버그수정 Bug fixes
- [X] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source
- 게시판 상세 입력 시 사용하는 `<textarea>` 컴포넌트의 이벤트를 `onChange`에서 `onBlur`로 변경  
- 긴 텍스트 입력 시 매 입력마다 상태 업데이트(setState)가 발생하던 문제를 방지  
- 포커스가 빠질 때(`onBlur`)에만 상태 변경이 일어나도록 하여 렌더링 최소화 및 UX 개선

## JUnit 테스트 JUnit tests
- [ ] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser
- [X] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video
