### PR TITLE
Fix(notice,gallery): 디테일 페이지 조회수 2회 증가 현상 수정

### DIFF
--- a/src/pages/admin/gallery/EgovAdminGalleryDetail.jsx
+++ b/src/pages/admin/gallery/EgovAdminGalleryDetail.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 
 import { Link, useLocation, useNavigate } from "react-router-dom";
 
@@ -69,10 +69,14 @@ function EgovAdminGalleryDetail(props) {
     });
   };
 
-  useEffect(function () {
-    retrieveDetail();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  const didFetchRef = useRef(false);
+
+  useEffect(() => {
+    if (!didFetchRef.current) {
+      didFetchRef.current = true;
+      retrieveDetail();
+    }
+  });
 
   console.groupEnd("EgovAdminGalleryDetail");
 

--- a/src/pages/admin/notice/EgovAdminNoticeDetail.jsx
+++ b/src/pages/admin/notice/EgovAdminNoticeDetail.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 
 import { Link, useLocation, useNavigate } from "react-router-dom";
 
@@ -67,10 +67,14 @@ function EgovAdminNoticeDetail(props) {
     });
   };
 
-  useEffect(function () {
-    retrieveDetail();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  const didFetchRef = useRef(false);
+
+  useEffect(() => {
+    if (!didFetchRef.current) {
+      didFetchRef.current = true;
+      retrieveDetail();
+    }
+  });
 
   console.groupEnd("EgovAdminNoticeDetail");
 

--- a/src/pages/inform/gallery/EgovGalleryDetail.jsx
+++ b/src/pages/inform/gallery/EgovGalleryDetail.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 
 import { Link, useLocation, useNavigate } from "react-router-dom";
 
@@ -75,10 +75,14 @@ function EgovGalleryDetail(props) {
     });
   };
 
-  useEffect(function () {
-    retrieveDetail();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  const didFetchRef = useRef(false);
+
+  useEffect(() => {
+    if (!didFetchRef.current) {
+      didFetchRef.current = true;
+      retrieveDetail();
+    }
+  });
 
   console.groupEnd("EgovGalleryDetail");
 

--- a/src/pages/inform/notice/EgovNoticeDetail.jsx
+++ b/src/pages/inform/notice/EgovNoticeDetail.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 
 import { Link, useLocation, useNavigate } from "react-router-dom";
 
@@ -73,10 +73,14 @@ function EgovNoticeDetail(props) {
     });
   };
 
-  useEffect(function () {
-    retrieveDetail();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  const didFetchRef = useRef(false);
+
+  useEffect(() => {
+    if (!didFetchRef.current) {
+      didFetchRef.current = true;
+      retrieveDetail();
+    }
+  });
 
   console.groupEnd("EgovNoticeDetail");
 


### PR DESCRIPTION
## 수정 사유 Reason for modification
- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source
useRef(didFetchRef)를 사용하여 retrieveDetail()이 한 번만 호출되도록 제한하였으며 이를 통해 동일한 컴포넌트가 리렌더링되거나 StrictMode 환경에서도 조회수가 1회만 증가하도록 보장됩니다.

수정 시 조회수가 2씩 증가 되는 현상이 마찬가지로 발견되지만, 백엔드에서 조회수 증가를 분기 처리 해야 하므로 추후 수정할 계획입니다.

## JUnit 테스트 JUnit tests
- [ ] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser
- [X] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video
