### PR TITLE
Fix(admin.gallery): 관리자 페이지 요청 URL을 /admin/board로 변경

### DIFF
--- a/src/pages/admin/gallery/EgovAdminGalleryDetail.jsx
+++ b/src/pages/admin/gallery/EgovAdminGalleryDetail.jsx
@@ -29,7 +29,7 @@ function EgovAdminGalleryDetail(props) {
   const [boardAttachFiles, setBoardAttachFiles] = useState();
 
   const retrieveDetail = () => {
-    const retrieveDetailURL = `/board/${bbsId}/${nttId}`;
+    const retrieveDetailURL = `/admin/board/${bbsId}/${nttId}`;
     const requestOptions = {
       method: "GET",
       headers: {
@@ -44,7 +44,7 @@ function EgovAdminGalleryDetail(props) {
   };
 
   const onClickDeleteBoardArticle = (bbsId, nttId, atchFileId) => {
-    const deleteBoardURL = `/board/${bbsId}/${nttId}`;
+    const deleteBoardURL = `/admin/board/${bbsId}/${nttId}`;
 
     const requestOptions = {
       method: "PATCH",

--- a/src/pages/admin/gallery/EgovAdminGalleryEdit.jsx
+++ b/src/pages/admin/gallery/EgovAdminGalleryEdit.jsx
@@ -72,7 +72,7 @@ function EgovAdminGalleryEdit(props) {
       };
 
       EgovNet.requestFetch(retrieveDetailURL, requestOptions, function (resp) {
-        setMasterBoard(resp.result.brdMstrVO);
+        setMasterBoard(resp.result);
       });
 
       setBoardDetail({ bbsId: bbsId, nttSj: "", nttCn: "" });

--- a/src/pages/admin/gallery/EgovAdminGalleryEdit.jsx
+++ b/src/pages/admin/gallery/EgovAdminGalleryEdit.jsx
@@ -35,7 +35,7 @@ function EgovAdminGalleryEdit(props) {
           ...modeInfo,
           modeTitle: "등록",
           method: "POST",
-          editURL: "/board",
+          editURL: "/admin/board",
         });
         break;
       case CODE.MODE_MODIFY:
@@ -43,7 +43,7 @@ function EgovAdminGalleryEdit(props) {
           ...modeInfo,
           modeTitle: "수정",
           method: "PUT",
-          editURL: `/board/${nttId}`,
+          editURL: `/admin/board/${nttId}`,
         });
         break;
       case CODE.MODE_REPLY:
@@ -51,7 +51,7 @@ function EgovAdminGalleryEdit(props) {
           ...modeInfo,
           modeTitle: "답글쓰기",
           method: "POST",
-          editURL: "/boardReply",
+          editURL: "/admin/boardReply",
         });
         break;
       default:
@@ -63,7 +63,7 @@ function EgovAdminGalleryEdit(props) {
   const retrieveDetail = () => {
     if (modeInfo.mode === CODE.MODE_CREATE) {
       // 등록이면 마스터 정보에서 파일 첨부 가능 여부 조회함
-      const retrieveDetailURL = `/boardFileAtch/${bbsId}`;
+      const retrieveDetailURL = `/admin/boardFileAtch/${bbsId}`;
       const requestOptions = {
         method: "GET",
         headers: {
@@ -79,7 +79,7 @@ function EgovAdminGalleryEdit(props) {
       return;
     }
 
-    const retrieveDetailURL = `/board/${bbsId}/${nttId}`;
+    const retrieveDetailURL = `/admin/board/${bbsId}/${nttId}`;
     const requestOptions = {
       method: "GET",
       headers: {

--- a/src/pages/admin/gallery/EgovAdminGalleryList.jsx
+++ b/src/pages/admin/gallery/EgovAdminGalleryList.jsx
@@ -40,7 +40,7 @@ function EgovAdminGalleryList(props) {
   const retrieveList = useCallback((searchCondition) => {
     console.groupCollapsed("EgovAdminGalleryList.retrieveList()");
 
-    const retrieveListURL = "/board" + EgovNet.getQueryString(searchCondition);
+    const retrieveListURL = "/admin/board" + EgovNet.getQueryString(searchCondition);
     const requestOptions = {
       method: "GET",
       headers: {

--- a/src/pages/admin/notice/EgovAdminNoticeEdit.jsx
+++ b/src/pages/admin/notice/EgovAdminNoticeEdit.jsx
@@ -72,7 +72,7 @@ function EgovAdminNoticeEdit(props) {
       };
 
       EgovNet.requestFetch(retrieveDetailURL, requestOptions, function (resp) {
-        setMasterBoard(resp.result.brdMstrVO);
+        setMasterBoard(resp.result );
       });
 
       setBoardDetail({ bbsId: bbsId, nttSj: "", nttCn: "" });
@@ -87,7 +87,7 @@ function EgovAdminNoticeEdit(props) {
       },
     };
     EgovNet.requestFetch(retrieveDetailURL, requestOptions, function (resp) {
-      setMasterBoard(resp.result.brdMstrVO);
+      setMasterBoard(resp.result);
 
       // 초기 boardDetail 설정 => ( 답글 / 수정 ) 모드일때...
       if (modeInfo.mode === CODE.MODE_REPLY) {


### PR DESCRIPTION
## 수정 사유 Reason for modification
- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source
- 관리자 페이지에서 게시판 데이터를 요청할 때 `/board` → `/admin/board`로 URL 경로를 수정했습니다.
- 이는 백엔드에서 일반 사용자와 관리자 요청을 분리하고 Spring Security로 관리자 권한을 제어하기 위함입니다.
- 일반 사용자용 게시판은 기존 URL인 `/board`를 그대로 사용합니다.

백엔드 PR 주소: [https://github.com/eGovFramework/egovframe-template-simple-backend/pull/83](https://github.com/eGovFramework/egovframe-template-simple-backend/pull/83)

## JUnit 테스트 JUnit tests
- [ ] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser
- [X] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video