### PR TITLE
Fix(mobile-menu): 모바일 메뉴에서 '사이트 관리' 메뉴 토글이 정상 동작하지 않던 문제 수정

### DIFF
--- a/src/js/ui.js
+++ b/src/js/ui.js
@@ -96,23 +96,6 @@ function handleSubmenuClick() {
   document.querySelector(".all_menu.Mobile").classList.add("closed");
 }
 
-function handleLastSubmenuClick(e) {
-  e.preventDefault();
-  const el = e.currentTarget;
-  el.classList.toggle("active");
-
-  const submenu = el.parentElement.nextElementSibling;
-  if (submenu && submenu.matches(".submenu")) {
-    if (submenu.classList.contains("closed")) {
-      submenu.style.height = submenu.scrollHeight + "px";
-      submenu.classList.remove("closed");
-    } else {
-      submenu.classList.add("closed");
-      submenu.style.height = "";
-    }
-  }
-}
-
 function handleWebMenuToggle(e) {
   const el = e.target;
 

--- a/src/js/ui.js
+++ b/src/js/ui.js
@@ -4,20 +4,6 @@ export default function initPage() {
   const sessionUser = sessionStorage.getItem("loginUser");
   const sessionUserId = JSON.parse(sessionUser)?.id;
 
-  if (sessionUserId === "admin") {
-    // Mobile 서브메뉴 항목 클릭시 메뉴 닫기
-    document.querySelectorAll(".all_menu.Mobile .submenu a").forEach((el) => {
-      el.removeEventListener("click", handleSubmenuClick);
-      el.addEventListener("click", handleSubmenuClick);
-    });
-
-    // 모바일 관리자 하위 메뉴 열고 닫기
-    const nodes = document.querySelectorAll(".all_menu.Mobile h3 a");
-    const last_submenu = nodes[nodes.length - 1];
-    last_submenu.removeEventListener("click", handleLastSubmenuClick);
-    last_submenu.addEventListener("click", handleLastSubmenuClick);
-  }
-
   if (init) return;
   init = true;
 
@@ -65,7 +51,13 @@ export default function initPage() {
   });
 
   // 모바일 하위 메뉴 열고 닫기
-  document.querySelectorAll(".all_menu.Mobile h3 a").forEach((el) => {
+  document.querySelectorAll(".all_menu.Mobile h3 a").forEach((el, i, arr) => {
+    if (i === arr.length - 1 && sessionUserId === "admin") {
+      el.removeEventListener("click", handleMobileSubmenuToggle);
+      el.addEventListener("click", handleMobileSubmenuToggle);
+      return;
+    }
+
     el.removeEventListener("click", handleMobileSubmenuToggle);
     el.addEventListener("click", handleMobileSubmenuToggle);
   });


### PR DESCRIPTION
## 수정 사유 Reason for modification
- [x] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source
### Fix(mobile-menu): 모바일 메뉴에서 '사이트 관리' 메뉴 토글이 정상 동작하지 않던 문제 수정
- 원인 : handleLastSubmenuClick과 handleMobileSubmenuToggle이 동시에 바인딩되어 중복 실행
- 수정1 : 모바일 하위 메뉴 관련 코드에서 마지막 요소(사이트 관리)는 admin일 경우에만 handleMobileSubmenuToggle 이벤트 등록
- 수정2 : 불필요해진 handleLastSubmenuClick 함수 및 해당 admin 전용 바인딩 로직 제거

## JUnit 테스트 JUnit tests
- [ ] JUnit 테스트 JUnit tests
- [x] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser
- [X] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video
<img width="775" height="704" alt="image" src="https://github.com/user-attachments/assets/ef1e72b6-7e1d-4ddc-96da-681eb3b158a2" />

