### PR TITLE
"홈페이지 템플릿 소개" 팝업 닫기 기능(키보드 사용성) 개선

### DIFF
--- a/src/js/ui.js
+++ b/src/js/ui.js
@@ -82,10 +82,18 @@ export default function initPage() {
     handleOpenPopup: function (e) {
       e.preventDefault();
       this.$tg.style.display = "block";
+      this.$tg.setAttribute("tabindex", "-1");
+      this.$tg.focus({ preventScroll: true });
+      this.$tg.addEventListener("keydown", this.handleEsc.bind(this));
     },
     handleClosePopup: function (e) {
       e.preventDefault();
       this.$tg.style.display = "none";
+      this.$tg.removeEventListener("keydown", this.handleEsc.bind(this));
+    },
+    handleEsc: function (e) {
+      if (e.key === "Escape")
+        this.handleClosePopup(e);
     },
   };
   document.querySelector(".lnk_go_template") && template.init();


### PR DESCRIPTION
[현재]
키보드만 이용하여 "홈페이지 템플릿 소개" 팝업을 열 수 있지만(Tab키로 물음표 선택 후, Enter)
팝업 닫기는 마우스 사용만 가능함.

[개선 사항]
1. Tab키로 'X'버튼 지정하여 닫기 가능하게 개선
2. Esc키로 닫기 가능하게 개선

## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [ ] 버그수정 Bug fixes
- [X] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.

### 수정 파일: src/js/ui.js
- 85~86행: Tab키가 기능하도록 tabindex 및 focus 지정
- 87행: Esc키가 기능하도록 닫기버튼에 핸들러 추가
- 92행: 팝업 닫힐때 이벤트 핸들러 제거
- 94~96행: Esc키 이벤트 핸들러 작성

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [ ] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [X] Chrome
- [ ] Firefox
- [X] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡처 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.

## [개선 전]
(팝업 오픈 후) Tab버튼 누른 경우 - Tab 포커스가 메인화면의 로고를 가리킴.
<img width="1579" height="385" alt="image" src="https://github.com/user-attachments/assets/d52445c3-2d05-422f-9415-058278c007ed" />

## [개선 후]
(팝업 오픈 후) Tab버튼 누른 경우 - Tab 포커스가 팝업의 X버튼을 가리킴.
<img width="1596" height="388" alt="image" src="https://github.com/user-attachments/assets/43763034-d908-481f-9193-bfbe291d8a9d" />

