### PR TITLE
[chore] Add Dependabot configuration for npm and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,29 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Seoul"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Seoul"
+    open-pull-requests-limit: 3
+    labels:
+      - "ci"
+    commit-message:
+      prefix: "ci"
+      include: "scope"


### PR DESCRIPTION
## 변경 사유
`.github/dependabot.yml` 미설치로 의존성/CI 액션 버전 관리가 수동입니다. React/Vite 프론트엔드의 의존성 패치와 GitHub Actions 버전 정합을 자동화합니다.

## 변경 내용
- `.github/dependabot.yml` 신규 추가
  - npm: 주간 스캔, 동시 PR 5개
  - github-actions: 주간 스캔, 동시 PR 3개
  - 스케줄: 매주 월요일 09:00 KST

## 영향 범위
- 기존 코드/빌드 영향 없음
- 머지 후 첫 월요일에 Dependabot 시작

## 체크리스트
- [x] 단일 주제(자동 의존성 관리 설정)
- [x] 5.0.x 브랜치 대상
- [x] 기존 동작 미변경