### PR TITLE
feat: 비밀번호 자릿수 확인 일관성 유지

### DIFF
--- a/src/pages/admin/members/EgovAdminMemberEdit.jsx
+++ b/src/pages/admin/members/EgovAdminMemberEdit.jsx
@@ -137,6 +137,10 @@ function EgovAdminMemberEdit(props) {
           alert("암호는 필수 값입니다.");
           return false;
         }
+        if (formData.get("password").length < 6) {
+          alert("암호는 6자 이상이어야 합니다.");
+          return false;
+        }
         if (formData.get("mberNm") === null || formData.get("mberNm") === "") {
           alert("회원명은 필수 값입니다.");
           return false;
@@ -167,6 +171,10 @@ function EgovAdminMemberEdit(props) {
     }
     if (checkRef.current[1].value === "") {
       memberDetail.password = ""; //수정 시 암호값을 입력하지 않으면 공백으로처리
+    }
+    if (checkRef.current[1].value !== "" && checkRef.current[1].value.length < 6) {
+      alert("암호는 6자 이상이어야 합니다.");
+      return false;
     }
     if (checkRef.current[2].value === "") {
       alert("회원명은 필수 값입니다.");

--- a/src/pages/mypage/EgovMypageEdit.jsx
+++ b/src/pages/mypage/EgovMypageEdit.jsx
@@ -145,6 +145,10 @@ function EgovMypageEdit(props) {
           alert("암호는 필수 값입니다.");
           return false;
         }
+        if (formData.get("password").length < 6) {
+          alert("암호는 6자 이상이어야 합니다.");
+          return false;
+        }
         if (formData.get("mberNm") === null || formData.get("mberNm") === "") {
           alert("회원명은 필수 값입니다.");
           return false;
@@ -161,6 +165,10 @@ function EgovMypageEdit(props) {
     }
     if (checkRef.current[1].value === "") {
       memberDetail.password = ""; //수정 시 암호값을 입력하지 않으면 공백으로처리
+    }
+    if (checkRef.current[1].value !== "" && checkRef.current[1].value.length < 6) {
+      alert("암호는 6자 이상이어야 합니다.");
+      return false;
     }
     if (checkRef.current[2].value === "") {
       alert("회원명은 필수 값입니다.");


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [ ] 버그수정 Bug fixes
- [x] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.

로그인할 때 "비밀번호는 6자 이상이어야 한다"고 유효성 체크를 하는데 아래 메뉴에서는 비밀번호 유효성 체크를 안하다보니 비밀번호 등록할 때는 4자리로 했는데 로그인할 때 6자 이상이어야 한다고 하니 로그인을 할 수 없는 현상 발생하여 아래 메뉴도 동일하게 유효성 체크를 해주었습니다.

- 회원가입
- 마이페이지 > 회원 수정 (일반 사용자)
- 사이트관리 > 회원관리 > 회원 등록 (관리자)
- 사이트관리 > 회원관리 > 회원 수정 (관리자)

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [ ] JUnit 테스트 JUnit tests
- [x] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡처 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.

[회원가입]
<img width="600" height="400" alt="회원가입" src="https://github.com/user-attachments/assets/b23df23f-2aa2-4ec8-a9c6-670aede9c669" />

[마이페이지 > 회원 수정 (일반 사용자)]
<img width="600" height="400" alt="마이페이지 회원 수정 (일반 사용자)" src="https://github.com/user-attachments/assets/2020b12f-a727-4fcf-95d2-888bf17628ce" />

[사이트관리 > 회원관리 > 회원 등록 (관리자)]
<img width="600" height="400" alt="사이트관리 회원관리 회원 등록 (관리자)" src="https://github.com/user-attachments/assets/3e00c340-5811-459a-9be3-a8e59ae27d04" />

[사이트관리 > 회원관리 > 회원 수정 (관리자)]
<img width="600" height="400" alt="사이트관리 회원관리 회원 수정 (관리자)" src="https://github.com/user-attachments/assets/118e587b-bafe-4a03-810c-55acea3f9327" />