### PR TITLE
[fix] 게시판 목록 역순 번호 계산에 pageSize 대신 recordCountPerPage 사용

### DIFF
--- a/src/pages/admin/board/EgovAdminBoardList.jsx
+++ b/src/pages/admin/board/EgovAdminBoardList.jsx
@@ -55,7 +55,7 @@ function EgovAdminBoardList(props) {
 
           const resultCnt = parseInt(resp.result.resultCnt);
           const currentPageNo = resp.result.paginationInfo.currentPageNo;
-          const pageSize = resp.result.paginationInfo.pageSize;
+          const recordCountPerPage = resp.result.paginationInfo.recordCountPerPage;
 
           // 리스트 항목 구성
           resp.result.resultList.forEach(function (item, index) {
@@ -63,7 +63,7 @@ function EgovAdminBoardList(props) {
             const listIdx = itemIdxByPage(
               resultCnt,
               currentPageNo,
-              pageSize,
+              recordCountPerPage,
               index
             );
 

--- a/src/pages/admin/gallery/EgovAdminGalleryList.jsx
+++ b/src/pages/admin/gallery/EgovAdminGalleryList.jsx
@@ -51,7 +51,7 @@ function EgovAdminGalleryList(props) {
 
         const resultCnt = parseInt(resp.result.resultCnt);
         const currentPageNo = resp.result.paginationInfo.currentPageNo;
-        const pageSize = resp.result.paginationInfo.pageSize;
+        const recordCountPerPage = resp.result.paginationInfo.recordCountPerPage;
 
         // 리스트 항목 구성
         resp.result.resultList.forEach(function (item, index) {
@@ -59,7 +59,7 @@ function EgovAdminGalleryList(props) {
           const listIdx = itemIdxByPage(
             resultCnt,
             currentPageNo,
-            pageSize,
+            recordCountPerPage,
             index
           );
 

--- a/src/pages/admin/members/EgovAdminMemberList.jsx
+++ b/src/pages/admin/members/EgovAdminMemberList.jsx
@@ -55,7 +55,7 @@ function EgovAdminMemberList(props) {
             resp.result.paginationInfo.totalRecordCount
           );
           const currentPageNo = resp.result.paginationInfo.currentPageNo;
-          const pageSize = resp.result.paginationInfo.pageSize;
+          const recordCountPerPage = resp.result.paginationInfo.recordCountPerPage;
           // 리스트 항목 구성
           resp.result.resultList.forEach(function (item, index) {
             let authNm = "";
@@ -66,7 +66,7 @@ function EgovAdminMemberList(props) {
             const listIdx = itemIdxByPage(
               resultCnt,
               currentPageNo,
-              pageSize,
+              recordCountPerPage,
               index
             );
             mutListTag.push(

--- a/src/pages/admin/notice/EgovAdminNoticeList.jsx
+++ b/src/pages/admin/notice/EgovAdminNoticeList.jsx
@@ -46,7 +46,7 @@ function EgovAdminNoticeList(props) {
 
         const resultCnt = parseInt(resp.result.resultCnt);
         const currentPageNo = resp.result.paginationInfo.currentPageNo;
-        const pageSize = resp.result.paginationInfo.pageSize;
+        const recordCountPerPage = resp.result.paginationInfo.recordCountPerPage;
 
         // 리스트 항목 구성
         resp.result.resultList.forEach(function (item, index) {
@@ -54,7 +54,7 @@ function EgovAdminNoticeList(props) {
           const listIdx = itemIdxByPage(
             resultCnt,
             currentPageNo,
-            pageSize,
+            recordCountPerPage,
             index
           );
 

--- a/src/pages/admin/usage/EgovAdminUsageList.jsx
+++ b/src/pages/admin/usage/EgovAdminUsageList.jsx
@@ -55,7 +55,7 @@ function EgovAdminUsageList(props) {
 
           const resultCnt = parseInt(resp.result.resultCnt);
           const currentPageNo = resp.result.paginationInfo.currentPageNo;
-          const pageSize = resp.result.paginationInfo.pageSize;
+          const recordCountPerPage = resp.result.paginationInfo.recordCountPerPage;
 
           // 리스트 항목 구성
           resp.result.resultList.forEach(function (item, index) {
@@ -63,7 +63,7 @@ function EgovAdminUsageList(props) {
             const listIdx = itemIdxByPage(
               resultCnt,
               currentPageNo,
-              pageSize,
+              recordCountPerPage,
               index
             );
 

--- a/src/pages/inform/gallery/EgovGalleryList.jsx
+++ b/src/pages/inform/gallery/EgovGalleryList.jsx
@@ -53,7 +53,7 @@ function EgovGalleryList(props) {
 
         const resultCnt = parseInt(resp.result.resultCnt);
         const currentPageNo = resp.result.paginationInfo.currentPageNo;
-        const pageSize = resp.result.paginationInfo.pageSize;
+        const recordCountPerPage = resp.result.paginationInfo.recordCountPerPage;
 
         // 리스트 항목 구성
         resp.result.resultList.forEach(function (item, index) {
@@ -61,7 +61,7 @@ function EgovGalleryList(props) {
           const listIdx = itemIdxByPage(
             resultCnt,
             currentPageNo,
-            pageSize,
+            recordCountPerPage,
             index
           );
 

--- a/src/pages/inform/notice/EgovNoticeList.jsx
+++ b/src/pages/inform/notice/EgovNoticeList.jsx
@@ -58,7 +58,7 @@ function EgovNoticeList(props) {
 
         const resultCnt = parseInt(resp.result.resultCnt);
         const currentPageNo = resp.result.paginationInfo.currentPageNo;
-        const pageSize = resp.result.paginationInfo.pageSize;
+        const recordCountPerPage = resp.result.paginationInfo.recordCountPerPage;
 
         // 리스트 항목 구성
         resp.result.resultList.forEach(function (item, index) {
@@ -66,7 +66,7 @@ function EgovNoticeList(props) {
           const listIdx = itemIdxByPage(
             resultCnt,
             currentPageNo,
-            pageSize,
+            recordCountPerPage,
             index
           );
 


### PR DESCRIPTION
## 변경 사유

목록 화면에서 항목의 역순 번호(listIdx)를 `itemIdxByPage`로 계산할 때, `resp.result.paginationInfo.pageSize`를 페이지당 레코드 수로 사용하고 있었습니다.

그런데 `PaginationInfo`의 실제 의미는 다릅니다.
- `recordCountPerPage`: 한 페이지당 게시되는 게시물 건 수
- `pageSize`: 페이지 리스트에 게시되는 페이지 건수(페이저에 보여줄 페이지 번호 개수)

백엔드에서도 이 둘을 서로 다른 값으로 명시적으로 설정하는 사례가 있습니다(`EgovMainApiController`: `recordCountPerPage=5`, `pageSize=10`). `Globals.pageUnit`과 `Globals.pageSize`가 기본값(10, 10)으로 같을 때는 드러나지 않지만, 둘을 다르게 설정한 게시판에서는 2페이지부터 역순 번호가 어긋납니다.

## 변경 내용

다음 7개 목록 화면에서 `paginationInfo.pageSize` → `paginationInfo.recordCountPerPage`로 수정했습니다.

- `EgovNoticeList.jsx`, `EgovGalleryList.jsx` (공지/갤러리)
- `EgovAdminBoardList.jsx`, `EgovAdminGalleryList.jsx`, `EgovAdminNoticeList.jsx`, `EgovAdminMemberList.jsx`, `EgovAdminUsageList.jsx` (관리자 목록)

`EgovPaging.jsx`의 `pageSize` 사용(페이저 그룹 크기)은 올바른 용례라 변경하지 않았습니다.

## 테스트 방법 / 영향 범위

`npm run build` 정상 통과, `npm run lint` 결과 기존에 있던 무관한 경고/에러(38건, 이 변경 전후 동일)만 남아있고 신규 문제는 없습니다. `Globals.pageUnit`과 `Globals.pageSize`를 다르게 설정한 게시판의 목록 화면에서 2페이지 이후 역순 번호가 정상적으로 계산되도록 동작이 수정됩니다.

- [x] 단일 주제만 다룸 (다른 변경 없음)
- [x] 영향 범위: 페이지당 레코드 수와 페이저 그룹 크기를 다르게 설정한 게시판의 목록 번호 계산이 정상화됨(기본 설정에선 두 값이 같아 눈에 띄지 않았음)
- [x] 빌드/린트 통과 확인