### PR TITLE
fix: README 백엔드 설정 안내가 무효(죽은 config 모듈) — 실제 동작 변수로 정정 + CRA 잔재 제거

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,10 +1,7 @@
-# 필수 지정 값
-
-## 절대경로 지정
-NODE_PATH=src/
-
-## 절대경로 지정
-VITE_APP_EGOV_CONTEXT_URL=localhost:8080
+# 개발 서버(vite dev) 관련 설정
+# - 백엔드가 별도 호스트에서 뜰 때는 아래 변수로 dev 프록시 대상을 바꾼다. (vite.config.js server.proxy)
+#   미지정 시 http://localhost:8080 을 사용한다.
+# VITE_APP_API_PROXY_TARGET=http://localhost:8080
 
 #SNS 간편로그인 변수
 VITE_APP_NAVER_CLIENTID=YOUR_CLIENT_ID

--- a/.env.production
+++ b/.env.production
@@ -1,10 +1,4 @@
-# 필수 지정 값
-
-## 절대경로 지정
-NODE_PATH=src/
-
-## 절대경로 지정
-VITE_EGOV_CONTEXT_URL=127.0.0.1:8080
-
-## [보안] 소스맵 삭제
-GENERATE_SOURCEMAP=false
+# 빌드 시 API base URL 설정
+# - 기본(미지정)은 동일 출처 상대경로 "/api" — nginx 리버스 프록시 배포와 일치 (src/config.js)
+# - 별도 호스트로 직접 호출해야 할 때만 절대 URL 지정
+# VITE_APP_API_BASE_URL=http://localhost:8080

--- a/README.md
+++ b/README.md
@@ -130,17 +130,22 @@ npm install
 
 ### 2. 백엔드 프로젝트 설정
 
-구동된 BackEnd 서버의 URL을 본 애플리케이션의 .env.development 파일의 VITE_APP_EGOV_CONTEXT_URL에 설정해 준다.
-(단, 개발환경에서는 사용하는 환경변수 정보는 .env.development, build 시 사용하는 환경변수는 .env.production 에 기입해 준다.)
+프론트엔드는 백엔드를 **동일 출처 상대경로 `/api`** 로 호출한다 (`src/config.js`의 `SERVER_URL`, 기본값 `/api`).
+개발 서버(`npm run dev`)는 `vite.config.js` 의 프록시 설정이 `/api/*` 요청을 백엔드로 전달하므로,
+백엔드가 `http://localhost:8080` 에서 구동 중이면 **추가 설정 없이 바로 동작한다**.
+
+백엔드가 다른 호스트/포트에서 뜰 때만 아래 변수를 사용한다.
 
 ```bash
-# .env.development 예시
-VITE_APP_EGOV_CONTEXT_URL=localhost:8080
+# 개발 서버의 프록시 대상 변경 (.env.development 또는 셸 환경변수)
+VITE_APP_API_PROXY_TARGET=http://192.168.0.10:8080
+
+# 빌드 산출물이 백엔드를 절대 URL로 직접 호출해야 할 때 (빌드 시점)
+VITE_APP_API_BASE_URL=http://api.example.com
 ```
 
-> `VITE_APP_EGOV_CONTEXT_URL` 은 개발 서버(`npm run dev`) 흐름에서 백엔드를 별도 호스트로 직접 호출할 때 사용하는 변수다.
-> 컨테이너/Kubernetes 배포에서는 nginx 가 `/api` 로 리버스 프록시하므로 이 변수 대신 `BACKEND_URL`(런타임 주입)을 사용한다.
-> 자세한 내용은 아래 "컨테이너 배포" 절을 참고한다.
+> 컨테이너/Kubernetes 배포에서는 nginx 가 `/api` 를 리버스 프록시하므로 위 변수 없이 기본값(`/api`)을 그대로 쓰고,
+> 백엔드 주소는 런타임에 `BACKEND_URL` 로 주입한다. 자세한 내용은 아래 "컨테이너 배포" 절을 참고한다.
 
 ### 3. 프로젝트 실행 및 기타 명령어
 

--- a/package.json
+++ b/package.json
@@ -34,6 +34,5 @@
     "preview": "vite preview",
     "test": "vitest",
     "test:run": "vitest run"
-  },
-  "proxy": "http://localhost:8080"
+  }
 }

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -1,4 +1,0 @@
-export const SERVER_URL = "http://" + import.meta.env.VITE_APP_EGOV_CONTEXT_URL; // REST API 서버 Domain URL
-export const DEFAULT_BBS_ID = "BBSMSTR_AAAAAAAAAAAA"; // default = 공지사항 게시판 아이디
-export const NOTICE_BBS_ID = "BBSMSTR_AAAAAAAAAAAA"; // 공지사항 게시판 아이디
-export const GALLERY_BBS_ID = "BBSMSTR_BBBBBBBBBBBB"; // 갤러리 게시판 아이디

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,4 +1,4 @@
-import { defineConfig } from "vite";
+import { defineConfig, loadEnv } from "vite";
 import react from "@vitejs/plugin-react-swc";
 import path from "path";
 import { fileURLToPath } from "url";
@@ -6,7 +6,12 @@ import { fileURLToPath } from "url";
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 // https://vitejs.dev/config/
-export default defineConfig(({ mode }) => ({
+export default defineConfig(({ mode }) => {
+  // config 평가 시점에는 .env 파일이 자동 로드되지 않으므로 loadEnv 로 명시적으로 읽는다.
+  // (셸 환경변수 + .env[.mode] 파일을 모두 병합해 반환한다)
+  // https://vite.dev/config/#using-environment-variables-in-config
+  const env = loadEnv(mode, process.cwd(), "");
+  return {
   plugins: [
     react({
       include: "**/*.{jsx,js}",
@@ -21,7 +26,7 @@ export default defineConfig(({ mode }) => ({
     // /api/board -> {target}/board 형태로 prefix 를 제거해 전달한다.
     proxy: {
       "/api": {
-        target: process.env.VITE_APP_API_PROXY_TARGET || "http://localhost:8080",
+        target: env.VITE_APP_API_PROXY_TARGET || "http://localhost:8080",
         changeOrigin: true,
         rewrite: (path) => path.replace(/^\/api/, ""),
       },
@@ -67,4 +72,5 @@ export default defineConfig(({ mode }) => ({
       },
     },
   },
-}));
+  };
+});


### PR DESCRIPTION
## 수정 사유 Reason for modification
- [X] 버그수정 Bug fixes
- [X] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 문제 (재현)

README **"2. 백엔드 프로젝트 설정"** 절 — 신규 개발자가 가장 먼저 따라 하는 절 — 은 `.env.development`의 `VITE_APP_EGOV_CONTEXT_URL`에 백엔드 URL을 설정하라고 안내합니다. **그런데 이 변수는 아무 효과가 없습니다.**

이 변수를 읽는 유일한 파일 `src/config/index.js`가 **죽은 코드**이기 때문입니다. `src/config.js`(파일)와 `src/config/index.js`(디렉터리)가 같은 4개 export를 동시에 정의하고 있고, Vite의 모듈 해석이 파일을 우선하므로 `src/config.js`만 로드됩니다.

**실증 1** — vitest 프로브로 어느 모듈이 로드되는지 확인:

```
[PROBE] @/config      -> SERVER_URL = "/api"     (config.js 값)
[PROBE] ../src/config -> SERVER_URL = "/api"
```

**실증 2** — README대로 설정된 상태(`VITE_APP_EGOV_CONTEXT_URL=localhost:8080`)로 개발 모드 빌드 후 번들 검사:

```
$ npx vite build --mode development
$ grep -o 'localhost:8080' dist/assets/*.js   → 결과 없음
$ grep -c '"/api"' dist/assets/*.js           → 1
```

번들에 `localhost:8080`이 전혀 없습니다. README 안내와 실제 동작이 불일치하고, README 자신도 뒤쪽 "컨테이너 배포" 절에서는 `src/config.js`·`VITE_APP_API_BASE_URL`을 올바르게 설명해 **문서 안에서 앞뒤가 모순**됩니다.

부수 위험: 죽은 `config/index.js`는 `"http://"`를 하드코딩하고 있어, 향후 누가 `@/config/index`로 직접 import하면 HTTPS 배포가 깨집니다.

## 수정 내용

1. **죽은 `src/config/index.js` 삭제** — 명시적 import 0건, 로드되지 않음을 실증
2. **README 설정 절 정정** — 실제 동작하는 두 변수로 교체:
   - dev 서버에서 백엔드가 별도 호스트일 때: `VITE_APP_API_PROXY_TARGET` (vite.config.js의 프록시 대상, 기존에 **미문서화** 상태였음)
   - 빌드 산출물이 절대 URL로 직접 호출해야 할 때: `VITE_APP_API_BASE_URL`
   - 기본 흐름(백엔드 localhost:8080)은 **추가 설정 없이 동작**함을 명시
3. **CRA 잔재 제거** (모두 Vite에서 무시됨):
   - `package.json`의 `"proxy"` 필드 (CRA 전용 — 실제 프록시는 vite.config.js에 있음)
   - `.env.*`의 `NODE_PATH`, `GENERATE_SOURCEMAP` (CRA 전용), `VITE_EGOV_CONTEXT_URL`(`_APP` 누락 오타로 아무도 읽지 않음)

## 검증

수정 후 전체 실행 (Node 20 / npm ci):

```
npx vitest run   → Test Files 9 passed (9) / Tests 44 passed (44)
npx vite build   → ✓ built (exit 0), 번들 API base "/api" 유지
```

- 삭제 파일은 로드되지 않던 코드이므로 **런타임 동작 변화 없음**
- package-lock.json은 건드리지 않았습니다 (`"proxy"`는 의존성 필드가 아니라 lock에 무관)

## 영향

- 신규 개발자가 README를 따라 하면 이제 실제로 동작합니다 (기존엔 무효 변수 설정 후 "왜 안 되지"를 겪는 흐름)
- 죽은 코드로 인한 미래 혼동(수정해도 반영 안 됨 / http 하드코딩) 제거
- 변경 범위: 5개 파일 +21 −30, 소스 코드 동작 변화 없음