### PR TITLE
fix: 검색 조건 없이 상세 화면 진입 시 목록 주소 생성이 깨지는 문제 수정

### DIFF
--- a/src/hooks/useListNavigation.js
+++ b/src/hooks/useListNavigation.js
@@ -67,7 +67,7 @@ export function useListNavigation(defaultBbsId) {
   const getBackToListURL = (baseURL, searchCondition) => {
     const searchParams = new URLSearchParams();
     if (searchCondition?.pageIndex > 1) searchParams.set('page', searchCondition.pageIndex);
-    if (searchCondition?.searchCnd !== "0") searchParams.set('searchCnd', searchCondition.searchCnd);
+    if (searchCondition?.searchCnd && searchCondition.searchCnd !== "0") searchParams.set('searchCnd', searchCondition.searchCnd);
     if (searchCondition?.searchWrd) searchParams.set('searchWrd', searchCondition.searchWrd);
 
     return `${baseURL}${searchParams.toString() ? '?' + searchParams.toString() : ''}`;

--- a/src/hooks/useListNavigation.test.jsx
+++ b/src/hooks/useListNavigation.test.jsx
@@ -1,0 +1,48 @@
+import { renderHook } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, it, expect } from "vitest";
+
+import { useListNavigation } from "@/hooks/useListNavigation";
+
+/**
+ * 상세 화면은 검색 조건을 `location.state?.searchCondition` 으로 읽는다 —
+ * 목록을 거치지 않고 들어오면 없다. 그때도 목록 주소는 만들어져야 한다.
+ */
+const wrapper = ({ children }) => <MemoryRouter>{children}</MemoryRouter>;
+
+describe("useListNavigation.getBackToListURL", () => {
+  const setup = () =>
+    renderHook(() => useListNavigation("BBSMSTR_BBBBBBBBBBBB"), { wrapper });
+
+  it("검색 조건이 없으면 목록 주소만 돌려준다", () => {
+    const { result } = setup();
+
+    expect(result.current.getBackToListURL("/inform/gallery", undefined)).toBe(
+      "/inform/gallery"
+    );
+  });
+
+  it("검색 조건이 있으면 쿼리로 붙인다", () => {
+    const { result } = setup();
+
+    expect(
+      result.current.getBackToListURL("/inform/gallery", {
+        pageIndex: 2,
+        searchCnd: "1",
+        searchWrd: "공지",
+      })
+    ).toBe("/inform/gallery?page=2&searchCnd=1&searchWrd=%EA%B3%B5%EC%A7%80");
+  });
+
+  it("기본 검색 조건은 쿼리를 만들지 않는다", () => {
+    const { result } = setup();
+
+    expect(
+      result.current.getBackToListURL("/inform/gallery", {
+        pageIndex: 1,
+        searchCnd: "0",
+        searchWrd: "",
+      })
+    ).toBe("/inform/gallery");
+  });
+});


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

`src/hooks/useListNavigation.js` 의 `getBackToListURL` 은 상세 화면에서 목록으로 돌아가는 주소를 만듭니다. 세 조건 모두 `searchCondition` 이 없을 수 있다고 보고 옵셔널 체이닝으로 접근하는데, 두 번째 조건의 **본문만** 옵셔널 없이 값을 읽습니다.

```js
if (searchCondition?.pageIndex > 1)       searchParams.set('page', searchCondition.pageIndex);
if (searchCondition?.searchCnd !== "0")   searchParams.set('searchCnd', searchCondition.searchCnd); // ← 본문에서 searchCondition.searchCnd
if (searchCondition?.searchWrd)           searchParams.set('searchWrd', searchCondition.searchWrd);
```

`searchCondition` 이 `undefined` 이면 `undefined !== "0"` 이 참이라 그 줄로 반드시 들어가고, `searchCondition.searchCnd` 를 읽는 순간 `TypeError: Cannot read properties of undefined (reading 'searchCnd')` 로 렌더가 중단됩니다.

상세 화면 네 곳(알림마당 공지·사이트갤러리, 사이트관리 공지·사이트갤러리)은 검색 조건을 `location.state?.searchCondition` 으로 읽습니다. 목록을 거쳐 들어오면 채워지지만, 상세 주소로 **바로 진입**하면(북마크, 링크 공유, 새로고침) 없습니다. 그때 이 화면들이 빈 화면이 됩니다.

특히 상세 화면에는 이미 `nttId` 가 없을 때 "잘못된 접근입니다" 를 띄우고 목록으로 돌려보내는 처리가 있는데, 그 `useEffect` 는 첫 렌더 이후에 실행되므로, 렌더 도중 발생하는 이 예외 때문에 그 안전장치까지 도달하지 못합니다.

값이 있을 때만 쿼리에 붙이도록 조건을 맞췄습니다.

```js
if (searchCondition?.searchCnd && searchCondition.searchCnd !== "0") searchParams.set('searchCnd', searchCondition.searchCnd);
```

## JUnit 테스트 JUnit tests

- [ ] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

`src/hooks/useListNavigation.test.jsx` 를 추가했습니다. `getBackToListURL` 을 세 경우로 확인합니다.

- 검색 조건이 없으면(undefined) 목록 주소만 반환 — 수정 전 RED(TypeError), 수정 후 GREEN
- 검색 조건이 있으면 쿼리로 붙임
- 기본 검색 조건(`searchCnd === "0"`)은 쿼리를 만들지 않음

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

검색 조건 없이 사이트갤러리 상세 주소로 바로 진입했을 때:

<img width="1280" height="800" alt="card3-ASIS-빈화면" src="https://github.com/user-attachments/assets/93eda030-2bbe-48dc-9008-f3f0f17d25ed" />

- 수정 전: 화면이 렌더 도중 중단되어 빈 화면이 됩니다.

<img width="1280" height="800" alt="card3-TOBE-목록복귀" src="https://github.com/user-attachments/assets/6745729a-d594-4918-862e-2725210efb09" />

- 수정 후: 화면이 정상적으로 렌더되고, 검색 조건이 없으므로 `nttId` 검증(잘못된 접근 안내)이 동작해 목록으로 돌아갑니다.

```
$ npm run test:run
 Test Files  10 passed (10)
      Tests  48 passed (48)
$ npm run lint    # 경고/에러 0
$ npm run build   # 정상
```

## 영향 범위

목록을 거쳐 상세로 들어가는 기존 흐름은 `searchCondition` 이 채워져 있어 동작이 같습니다. 상세 주소로 바로 진입하는 경우에만 화면이 정상적으로 뜨도록 고쳐집니다. 네 상세 화면이 모두 이 훅을 공유합니다.
