### PR TITLE
fix: 인증 오류 응답이 화면 핸들러로 전달돼 오류 알림이 중복되는 문제 수정

### DIFF
--- a/src/api/egovFetch.js
+++ b/src/api/egovFetch.js
@@ -26,12 +26,9 @@ export function requestFetch(url, requestOptions, handler, errorHandler) {
         alert("Login Alert");
         setSessionItem("loginUser", { id: "" });
         window.location.href = URL.LOGIN;
-        return false;
-      } else {
-        return resp;
+        return;
       }
-    })
-    .then((resp) => {
+
       if (typeof handler === "function") {
         handler(resp);
       } else {

--- a/src/api/egovFetch.test.js
+++ b/src/api/egovFetch.test.js
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import { requestFetch } from "@/api/egovFetch";
+import CODE from "@/constants/code";
+
+/**
+ * 인증 오류 응답은 로그인 화면으로 보내고 거기서 끝나야 한다.
+ * 응답 본문을 화면 핸들러에 넘기면 핸들러가 `resp.result.*` 를 읽다 깨진다.
+ */
+describe("requestFetch 인증 오류 처리", () => {
+  let alertSpy;
+
+  beforeEach(() => {
+    alertSpy = vi.spyOn(window, "alert").mockImplementation(() => {});
+    // jsdom 은 실제 이동을 구현하지 않는다 — 대입만 받아 두고 넘어간다.
+    delete window.location;
+    window.location = { href: "" };
+    global.fetch = vi.fn(() =>
+      Promise.resolve({
+        json: () => Promise.resolve({ resultCode: CODE.RCV_ERROR_AUTH }),
+      })
+    );
+  });
+
+  afterEach(() => {
+    alertSpy.mockRestore();
+    vi.restoreAllMocks();
+  });
+
+  it("인증 오류면 화면 핸들러를 부르지 않는다", async () => {
+    const handler = vi.fn();
+
+    requestFetch("/board", { method: "GET" }, handler);
+    await vi.waitFor(() => expect(alertSpy).toHaveBeenCalled());
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("인증 오류가 화면 오류 알림을 덧붙이지 않는다", async () => {
+    // 실제 화면 핸들러가 하는 일 — 목록 3종이 전부 이 모양이다.
+    const handler = vi.fn((resp) => {
+      void resp.result.brdMstrVO;
+    });
+    const errorHandler = vi.fn();
+
+    requestFetch("/board", { method: "GET" }, handler, errorHandler);
+    await vi.waitFor(() => expect(alertSpy).toHaveBeenCalled());
+
+    expect(errorHandler).not.toHaveBeenCalled();
+    expect(alertSpy).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

`src/api/egovFetch.js` 의 `requestFetch` 는 인증 오류(`RCV_ERROR_AUTH`) 분기에서 `return false` 로 처리를 끝내려 하지만, 그 `return` 은 콜백에서 값을 돌려줄 뿐이라 다음 `.then((resp) => handler(resp))` 이 그 `false` 를 응답으로 받습니다. 화면 핸들러는 `resp.result.*` 를 읽으므로 `TypeError` 가 나고, 그 예외가 `.catch` 로 흘러 오류 알림이 한 번 더 뜹니다 — 세션 만료 시 "Login Alert" 뒤에 "요청 처리 중 오류가 발생했습니다" 가 이어집니다.

두 `.then` 을 하나로 합쳐 인증 오류 분기에서 핸들러를 부르지 않고 끝나게 했습니다.

```js
if (Number(resp.resultCode) === Number(CODE.RCV_ERROR_AUTH)) {
  alert("Login Alert");
  setSessionItem("loginUser", { id: "" });
  window.location.href = URL.LOGIN;
  return;
}
if (typeof handler === "function") handler(resp);
```

## JUnit 테스트 JUnit tests

- [ ] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

`src/api/egovFetch.test.js` — 인증 오류를 목킹하고 화면 핸들러가 목록 응답(`resp.result.brdMstrVO`)을 읽는 모양을 재현. 수정 전 핸들러가 `false` 를 받아 `TypeError`(RED), 수정 후 핸들러 미호출·알림 1회(GREEN).

```
$ npm run test:run   # 47 passed
$ npm run lint       # 0
$ npm run build      # 정상
```

## 영향 범위

`errorHandler` 를 넘기는 호출부는 `src/api/services/mainPage.js` 하나이며 그 소비자(`EgovMain`)는 `try/catch` 로 조용히 처리합니다. 정상 응답 경로는 그대로입니다.
