### PR TITLE
fix: 사이트갤러리 수정·저장 버튼 노출을 인증 상태 기준으로 판단

### DIFF
--- a/src/pages/inform/gallery/EgovGalleryDetail.jsx
+++ b/src/pages/inform/gallery/EgovGalleryDetail.jsx
@@ -11,16 +11,11 @@ import { GALLERY_BBS_ID } from "@/config";
 import { default as EgovLeftNav } from "@/components/leftmenu/EgovLeftNavInform";
 import EgovAttachFile from "@/components/EgovAttachFile";
 import EgovImageGallery from "@/components/EgovImageGallery";
-import { getSessionItem } from "@/utils/storage";
 
 function EgovGalleryDetail() {
 
   const navigate = useNavigate();
   const location = useLocation();
-
-  //관리자 권한 체크때문에 추가(아래)
-  const sessionUser = getSessionItem("loginUser");
-  const sessionUniqId = sessionUser?.uniqId;
 
   const bbsId = location.state?.bbsId || GALLERY_BBS_ID;
   const nttId = location.state?.nttId;
@@ -168,7 +163,7 @@ function EgovGalleryDetail() {
               </div>
 
               <div className="board_btn_area">
-                {sessionUniqId === boardDetail.frstRegisterId &&
+                {user?.uniqId === boardDetail.frstRegisterId &&
                   user?.id &&
                   masterBoard.bbsUseFlag === "Y" && (
                     <div className="left_col btn3">

--- a/src/pages/inform/gallery/EgovGalleryDetail.test.jsx
+++ b/src/pages/inform/gallery/EgovGalleryDetail.test.jsx
@@ -1,0 +1,77 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import EgovGalleryDetail from "@/pages/inform/gallery/EgovGalleryDetail";
+
+/**
+ * JWT 는 httpOnly 쿠키라 새 탭에도 붙지만 sessionStorage 는 탭마다 별개다.
+ * 그래서 로그인 여부·작성자 여부는 응답이 준 user 로만 판정해야 한다.
+ */
+const OWNER = "USRCNFRM_00000000001";
+
+const detailResponse = {
+  resultCode: 200,
+  result: {
+    brdMstrVO: { bbsUseFlag: "Y", replyPosblAt: "N", fileAtchPosblAt: "N" },
+    boardVO: { bbsId: "BBSMSTR_BBBBBBBBBBBB", nttId: 1, frstRegisterId: OWNER },
+    user: { id: "tester", uniqId: OWNER },
+    resultFiles: [],
+  },
+};
+
+const renderDetail = () =>
+  render(
+    <MemoryRouter
+      initialEntries={[
+        {
+          pathname: "/",
+          state: {
+            bbsId: "BBSMSTR_BBBBBBBBBBBB",
+            nttId: 1,
+            searchCondition: { pageIndex: 1, searchCnd: "0", searchWrd: "" },
+          },
+        },
+      ]}
+    >
+      <EgovGalleryDetail />
+    </MemoryRouter>
+  );
+
+describe("사이트갤러리 상세", () => {
+  beforeEach(() => {
+    sessionStorage.clear(); // 새 탭 — 이 탭에는 로그인 캐시가 없다
+    global.fetch = vi.fn(() =>
+      Promise.resolve({ json: () => Promise.resolve(detailResponse) })
+    );
+  });
+
+  it("새 탭에서 열어도 작성자 본인에게 수정·삭제 버튼을 보여준다", async () => {
+    renderDetail();
+
+    await waitFor(() =>
+      expect(screen.getByRole("link", { name: "수정" })).toBeInTheDocument()
+    );
+    expect(screen.getByText("삭제")).toBeInTheDocument();
+  });
+
+  it("작성자가 아니면 수정 버튼을 보여주지 않는다", async () => {
+    global.fetch = vi.fn(() =>
+      Promise.resolve({
+        json: () =>
+          Promise.resolve({
+            ...detailResponse,
+            result: {
+              ...detailResponse.result,
+              user: { id: "other", uniqId: "USRCNFRM_00000000002" },
+            },
+          }),
+      })
+    );
+
+    renderDetail();
+
+    await waitFor(() => expect(global.fetch).toHaveBeenCalled());
+    expect(screen.queryByRole("link", { name: "수정" })).not.toBeInTheDocument();
+  });
+});

--- a/src/pages/inform/gallery/EgovGalleryEdit.jsx
+++ b/src/pages/inform/gallery/EgovGalleryEdit.jsx
@@ -10,13 +10,12 @@ import { GALLERY_BBS_ID } from "@/config";
 import { default as EgovLeftNav } from "@/components/leftmenu/EgovLeftNavInform";
 import EgovAttachFile from "@/components/EgovAttachFile";
 import bbsFormVaildator from "@/utils/bbsFormVaildator";
-import { getSessionItem } from "@/utils/storage";
+import { useAuth } from "@/contexts/AuthContext";
 import { useDebouncedInput } from "@/hooks/useDebounce";
 
 function EgovGalleryEdit(props) {
-  //관리자 권한 체크때문에 추가(아래)
-  const sessionUser = getSessionItem("loginUser");
-  const sessionId = sessionUser?.id;
+  // 로그인 여부는 백엔드 /auth/me 결과 사용
+  const { user } = useAuth();
 
   const navigate = useNavigate();
   const location = useLocation();
@@ -244,7 +243,7 @@ function EgovGalleryEdit(props) {
                 )}
               {/* <!-- 버튼영역 --> */}
               <div className="board_btn_area">
-                {sessionId && (
+                {user?.id && (
                   <div className="left_col btn1">
                     <a
                       href="#!"


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

사이트갤러리 상세·수정 화면이 수정·저장 버튼 노출을 `sessionStorage` 의 `loginUser` 로 판단합니다. 로그인 토큰은 `httpOnly` 쿠키라 브라우저가 새 탭에도 붙이지만 `sessionStorage` 는 탭마다 별개라, 로그인한 사용자가 글을 새 탭으로 열면(가운데 클릭·새 탭에서 열기·링크 붙여넣기) 백엔드는 로그인 상태를 정상 인식하는데도 자기 글의 수정·삭제 버튼과 등록 화면의 저장 버튼이 사라집니다.

`AuthContext` 는 이미 "`sessionStorage` 의 `loginUser` 는 표시용 보조 캐시로만 사용" 이라 명시하고, 공지사항 화면들은 백엔드 `/auth/me` 결과를 씁니다. 사이트갤러리도 응답이 주는 인증 정보로 판단하도록 맞췄습니다.

- 상세: 이미 받고 있는 응답 `result.user` 의 `uniqId` 로 작성자 대조
- 수정: 공지사항 수정 화면과 같이 `useAuth()` 의 `user` 로 로그인 여부 판단

게시판 정책(사이트갤러리는 로그인 일반 사용자 등록·수정, 자기 글은 작성자 본인만)과 서버 소유권 검증은 그대로입니다(#131).

## JUnit 테스트 JUnit tests

- [ ] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

`src/pages/inform/gallery/EgovGalleryDetail.test.jsx` — `sessionStorage.clear()`(새 탭)에서 응답 `user` 만으로 판단. 작성자에게 수정·삭제 버튼 노출, 비작성자에게 미노출. 수정 전 RED(새 탭에 버튼 없음), 후 GREEN.

```
$ npm run test:run   # 47 passed
$ npm run lint       # 0
$ npm run build      # 정상
```
