### PR TITLE
fix: 일정 수정 저장 URL 을 상태 변이 대신 지역 변수로 계산

### DIFF
--- a/src/pages/admin/schedule/EgovAdminScheduleEdit.jsx
+++ b/src/pages/admin/schedule/EgovAdminScheduleEdit.jsx
@@ -122,11 +122,14 @@ function EgovAdminScheduleEdit(props) {
         body: formData,
       };
 
-      if (modeInfo.mode === CODE.MODE_MODIFY) {
-        modeInfo.editURL = `${modeInfo.editURL}/${location.state?.schdulId}`;
-      }
+      // 형제 게시판 수정 화면들처럼 수정 URL 을 여기서 한 번 계산한다.
+      // 상태(modeInfo.editURL)를 제자리에서 이어 붙이면 저장을 다시 누를 때 겹친다.
+      const editURL =
+        modeInfo.mode === CODE.MODE_MODIFY
+          ? `${modeInfo.editURL}/${location.state?.schdulId}`
+          : modeInfo.editURL;
 
-      EgovNet.requestFetch(modeInfo.editURL, requestOptions, (resp) => {
+      EgovNet.requestFetch(editURL, requestOptions, (resp) => {
         if (Number(resp.resultCode) === Number(CODE.RCV_SUCCESS)) {
           navigate({ pathname: URL.ADMIN_SCHEDULE });
         } else {

--- a/src/pages/admin/schedule/EgovAdminScheduleEdit.test.jsx
+++ b/src/pages/admin/schedule/EgovAdminScheduleEdit.test.jsx
@@ -1,0 +1,70 @@
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import EgovAdminScheduleEdit from "@/pages/admin/schedule/EgovAdminScheduleEdit";
+import CODE from "@/constants/code";
+
+/**
+ * 일정 수정 저장 URL 은 modeInfo.editURL(상태)을 제자리에서 이어 붙여 만든다.
+ * 형제 게시판 수정 화면들은 수정 URL 을 초기화 때 한 번 완성하는데,
+ * 이 화면만 저장할 때마다 상태를 덧붙이므로 저장이 두 번 불리면 id 가 겹친다.
+ */
+const SCHDUL_ID = "SCHDUL_00000000000123";
+const detail = {
+  resultCode: 200,
+  result: {
+    scheduleDetail: {
+      schdulId: SCHDUL_ID,
+      schdulNm: "회의",
+      schdulCn: "정기 회의",
+      schdulSe: "1",
+      schdulIpcrCode: "1",
+      reptitSeCode: "0",
+      schdulBgnde: "20260101000000",
+      schdulEndde: "20260101010000",
+      atchFileId: "",
+    },
+    resultFiles: [],
+  },
+};
+
+describe("일정 수정 저장 URL", () => {
+  beforeEach(() => {
+    vi.spyOn(window, "alert").mockImplementation(() => {});
+    global.fetch = vi.fn(() =>
+      Promise.resolve({ json: () => Promise.resolve(detail) })
+    );
+  });
+
+  it("저장을 두 번 눌러도 수정 URL 에 일정 ID 가 한 번만 붙는다", async () => {
+    render(
+      <MemoryRouter initialEntries={[{ pathname: "/", state: { schdulId: SCHDUL_ID } }]}>
+        <EgovAdminScheduleEdit mode={CODE.MODE_MODIFY} />
+      </MemoryRouter>
+    );
+
+    // 상세 조회가 끝나 폼이 채워질 때까지
+    await waitFor(() => expect(global.fetch).toHaveBeenCalled());
+
+    const save = await screen.findByText("저장");
+    fireEvent.click(save);
+    fireEvent.click(save);
+
+    await waitFor(() => {
+      const puts = global.fetch.mock.calls.filter(
+        (c) => (c[1]?.method || "GET") === "PUT"
+      );
+      expect(puts.length).toBeGreaterThanOrEqual(2);
+    });
+
+    const putUrls = global.fetch.mock.calls
+      .filter((c) => (c[1]?.method || "GET") === "PUT")
+      .map((c) => c[0]);
+    // 모든 저장 요청이 같은 URL 이어야 한다
+    for (const u of putUrls) {
+      expect(u).toContain(`/schedule/${SCHDUL_ID}`);
+      expect(u).not.toContain(`${SCHDUL_ID}/${SCHDUL_ID}`);
+    }
+  });
+});


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

`src/pages/admin/schedule/EgovAdminScheduleEdit.jsx` 의 저장은 일정 수정 URL 을 `modeInfo.editURL`(상태 객체)에 직접 이어 붙입니다.

```js
if (modeInfo.mode === CODE.MODE_MODIFY) {
  modeInfo.editURL = `${modeInfo.editURL}/${location.state?.schdulId}`; // 상태를 제자리 변이
}
```

형제 게시판 수정 화면들(공지·사이트갤러리·게시판 관리)은 수정 URL 을 초기화 때 `editURL: /board/${nttId}` 로 한 번 완성하는데, 일정만 저장 시점에 상태를 덧붙입니다. `setState` 없이 상태를 변이하므로 저장이 두 번 호출되면(저장 버튼 이중 클릭 등) `editURL` 이 이미 `/schedule/{id}` 인 채로 다시 붙어 `/schedule/{id}/{id}` 가 되고, 두 번째 요청이 존재하지 않는 경로로 나가 오류 화면으로 이동합니다.

수정 URL 을 요청 직전에 지역 변수로 계산하도록 바꿨습니다. 형제 화면들과 같은 방식입니다.

```js
const editURL =
  modeInfo.mode === CODE.MODE_MODIFY
    ? `${modeInfo.editURL}/${location.state?.schdulId}`
    : modeInfo.editURL;
```

## JUnit 테스트 JUnit tests

- [ ] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

`src/pages/admin/schedule/EgovAdminScheduleEdit.test.jsx` — 일정 수정 화면에서 저장을 두 번 눌러 두 요청 URL 을 확인. 수정 전 둘째가 `/schedule/{id}/{id}`(RED), 후 둘 다 `/schedule/{id}`(GREEN).

```
$ npm run test:run   # 46 passed
$ npm run lint       # 0
$ npm run build      # 정상
```
