### PR TITLE
fix: bbsFormVaildator 오탈자 수정 (Vaildator→Validator)

### DIFF
--- a/src/pages/admin/gallery/EgovAdminGalleryEdit.jsx
+++ b/src/pages/admin/gallery/EgovAdminGalleryEdit.jsx
@@ -9,7 +9,7 @@ import { GALLERY_BBS_ID } from "@/config";
 
 import { default as EgovLeftNav } from "@/components/leftmenu/EgovLeftNavAdmin";
 import EgovAttachFile from "@/components/EgovAttachFile";
-import bbsFormVaildator from "@/utils/bbsFormVaildator";
+import bbsFormValidator from "@/utils/bbsFormValidator";
 import { useDebouncedInput } from "@/hooks/useDebounce";
 
 function EgovAdminGalleryEdit(props) {
@@ -111,7 +111,7 @@ function EgovAdminGalleryEdit(props) {
       formData.append(key, boardDetail[key]);
     }
 
-    if (bbsFormVaildator(formData)) {
+    if (bbsFormValidator(formData)) {
       const requestOptions = {
         method: modeInfo.method,
         body: formData,

--- a/src/pages/admin/notice/EgovAdminNoticeEdit.jsx
+++ b/src/pages/admin/notice/EgovAdminNoticeEdit.jsx
@@ -9,7 +9,7 @@ import { NOTICE_BBS_ID } from "@/config";
 
 import { default as EgovLeftNav } from "@/components/leftmenu/EgovLeftNavAdmin";
 import EgovAttachFile from "@/components/EgovAttachFile";
-import bbsFormVaildator from "@/utils/bbsFormVaildator";
+import bbsFormValidator from "@/utils/bbsFormValidator";
 
 import { useDebouncedInput } from "@/hooks/useDebounce";
 
@@ -112,7 +112,7 @@ function EgovAdminNoticeEdit(props) {
       formData.append(key, boardDetail[key]);
     }
 
-    if (bbsFormVaildator(formData)) {
+    if (bbsFormValidator(formData)) {
       const requestOptions = {
         method: modeInfo.method,
         body: formData,

--- a/src/pages/inform/gallery/EgovGalleryEdit.jsx
+++ b/src/pages/inform/gallery/EgovGalleryEdit.jsx
@@ -9,7 +9,7 @@ import { GALLERY_BBS_ID } from "@/config";
 
 import { default as EgovLeftNav } from "@/components/leftmenu/EgovLeftNavInform";
 import EgovAttachFile from "@/components/EgovAttachFile";
-import bbsFormVaildator from "@/utils/bbsFormVaildator";
+import bbsFormValidator from "@/utils/bbsFormValidator";
 import { useAuth } from "@/contexts/AuthContext";
 import { useDebouncedInput } from "@/hooks/useDebounce";
 
@@ -114,7 +114,7 @@ function EgovGalleryEdit(props) {
       formData.append(key, boardDetail[key]);
     }
 
-    if (bbsFormVaildator(formData)) {
+    if (bbsFormValidator(formData)) {
       const requestOptions = {
         method: modeInfo.method,
         body: formData,

--- a/src/pages/inform/notice/EgovNoticeEdit.jsx
+++ b/src/pages/inform/notice/EgovNoticeEdit.jsx
@@ -9,7 +9,7 @@ import { NOTICE_BBS_ID } from "@/config";
 
 import { default as EgovLeftNav } from "@/components/leftmenu/EgovLeftNavInform";
 import EgovAttachFile from "@/components/EgovAttachFile";
-import bbsFormVaildator from "@/utils/bbsFormVaildator";
+import bbsFormValidator from "@/utils/bbsFormValidator";
 import { useAuth } from "@/contexts/AuthContext";
 import { useDebouncedInput } from "@/hooks/useDebounce";
 
@@ -115,7 +115,7 @@ function EgovNoticeEdit(props) {
       formData.append(key, boardDetail[key]);
     }
 
-    if (bbsFormVaildator(formData)) {
+    if (bbsFormValidator(formData)) {
       const requestOptions = {
         method: modeInfo.method,
         body: formData,

--- a/src/utils/bbsFormValidator.js
+++ b/src/utils/bbsFormValidator.js
@@ -1,4 +1,4 @@
-const bbsFormVaildator = (formData) => {
+const bbsFormValidator = (formData) => {
     if (formData.get('nttSj') === null || formData.get('nttSj') === "") {
         alert("제목은 필수 값입니다.");
         return false;
@@ -10,4 +10,4 @@ const bbsFormVaildator = (formData) => {
     return true;
 };
 
-export default bbsFormVaildator;
+export default bbsFormValidator;


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [ ] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [X] 기타 Others (오탈자 수정)

## 수정된 소스 내용 Modified source

`bbsFormVaildator` 의 `Vaildator` 오탈자를 `Validator` 로 바로잡았습니다.

- `src/utils/bbsFormVaildator.js` → `src/utils/bbsFormValidator.js` (파일명, `git mv` 로 이력 유지)
- 함수명 및 default export 식별자
- import / 호출부 4곳
  - `src/pages/inform/notice/EgovNoticeEdit.jsx`
  - `src/pages/inform/gallery/EgovGalleryEdit.jsx`
  - `src/pages/admin/notice/EgovAdminNoticeEdit.jsx`
  - `src/pages/admin/gallery/EgovAdminGalleryEdit.jsx`

식별자 rename 만 수행했으며 로직·동작 변경은 없습니다. 저장소 전체에 `Vaildator` 잔여 참조가 없는 것을 확인했습니다.

### 현재 open PR 과의 관계

변경 파일이 아래 open PR 과 겹칩니다. 머지 순서에 참고 부탁드립니다.

| PR | 겹치는 파일 |
|---|---|
| #103 (MenuHeader 공통화) | `EgovNoticeEdit.jsx`, `EgovGalleryEdit.jsx`, `EgovAdminNoticeEdit.jsx`, `EgovAdminGalleryEdit.jsx` (4개 전부) |
| #134 (사이트갤러리 버튼 노출) | `EgovGalleryEdit.jsx` |

특히 **#103 은 본 PR 이 수정하는 import 줄 바로 아래에 `EgovMenuHeader` import 를 추가**합니다. 본 PR 이 먼저 머지될 경우 #103 브랜치에는 삭제된 경로(`@/utils/bbsFormVaildator`)를 참조하는 import 가 남게 되며, rename 은 내용 충돌로 감지되지 않을 수 있어 자동 머지 후 빌드가 깨질 수 있습니다.

- 본 PR 이 먼저 머지되면 → #103 · #134 에서 `bbsFormVaildator` → `bbsFormValidator` 로 import 경로·식별자 갱신 필요
- #103 이 먼저 머지되면 → 본 PR 을 rebase 하여 재적용하겠습니다


## JUnit 테스트 JUnit tests

- [X] 단위 테스트 (이 저장소는 vitest 사용) — `npm run test:run` : 11개 파일 / 50개 테스트 전부 통과
- [ ] 수동 테스트 Manual testing

추가로 `npm run lint` (`--max-warnings 0`) 경고 0건을 확인했습니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

UI 및 런타임 동작 변경이 없는 식별자 rename 이라 브라우저별 수동 테스트는 수행하지 않았습니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

화면 변경 사항이 없어 첨부할 스크린샷이 없습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
