### PR TITLE
fix(api): 목록 조회 쿼리스트링이 검색어를 인코딩하지 않아 조건이 잘리는 문제 수정

### DIFF
--- a/src/api/egovFetch.js
+++ b/src/api/egovFetch.js
@@ -6,9 +6,7 @@ import { setSessionItem } from "@/utils/storage";
 import { logger } from "@/utils/logger";
 
 export function getQueryString(params) {
-  return `?${Object.entries(params)
-    .map((e) => e.join("="))
-    .join("&")}`;
+  return `?${new URLSearchParams(params).toString()}`;
 }
 
 export function requestFetch(url, requestOptions, handler, errorHandler) {

--- a/src/api/egovFetch.test.js
+++ b/src/api/egovFetch.test.js
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
-import { requestFetch } from "@/api/egovFetch";
+import { getQueryString, requestFetch } from "@/api/egovFetch";
 import CODE from "@/constants/code";
 
 /**
@@ -48,5 +48,33 @@ describe("requestFetch 인증 오류 처리", () => {
 
     expect(errorHandler).not.toHaveBeenCalled();
     expect(alertSpy).toHaveBeenCalledTimes(1);
+  });
+});
+
+/**
+ * 목록 조회 쿼리스트링은 사용자가 입력한 검색어를 그대로 싣는다.
+ * 인코딩하지 않으면 `#` 뒤가 잘리고 `&` 가 파라미터를 쪼개 서버가 다른 조건으로 조회한다.
+ * 같은 검색어를 주소창에 남기는 useListNavigation 은 이미 인코딩한다.
+ */
+describe("getQueryString", () => {
+  it("검색어의 특수문자를 인코딩한다", () => {
+    expect(
+      getQueryString({
+        bbsId: "BBSMSTR_AAA",
+        pageIndex: 1,
+        searchCnd: "0",
+        searchWrd: "C#5 & C++",
+      })
+    ).toBe("?bbsId=BBSMSTR_AAA&pageIndex=1&searchCnd=0&searchWrd=C%235+%26+C%2B%2B");
+  });
+
+  it("인코딩한 쿼리스트링에서 원래 검색어를 되읽을 수 있다", () => {
+    const searchWrd = "C#5 & C++";
+    const url = new URL(
+      "/board" + getQueryString({ bbsId: "BBSMSTR_AAA", searchWrd }),
+      "http://localhost"
+    );
+
+    expect(url.searchParams.get("searchWrd")).toBe(searchWrd);
   });
 });


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

`src/api/egovFetch.js:8-12`의 `getQueryString`이 쿼리스트링을 날 문자열로 이어 붙입니다.

```js
export function getQueryString(params) {
  return `?${Object.entries(params)
    .map((e) => e.join("="))
    .join("&")}`;
}
```

검색어에 `#`이 들어가면 그 뒤가 프래그먼트로 잘리고, `&`가 들어가면 파라미터가 쪼개집니다. 공지사항 검색창에 `C#5 & C++`를 넣고 조회하면 서버가 받는 `searchWrd`는 `C`입니다.

같은 저장소가 다른 두 경로에서는 이미 인코딩하고 있습니다.

- `src/hooks/useListNavigation.js:29-34` — 주소창에 검색 조건을 남길 때 `URLSearchParams`를 씁니다.
- `src/components/EgovAttachFile.jsx:34-35` — 첨부파일 내려받기 주소에 `encodeURIComponent`를 씁니다.

그래서 같은 검색 한 번에 주소창은 `?searchCnd=0&searchWrd=C%235+%26+C%2B%2B`로 정확히 남는데 실제 요청만 `&searchWrd=C`로 잘립니다. 그 주소로 새로고침하면 `useListNavigation.js:13-21`이 조건을 되읽고, `EgovNoticeList.jsx:104-107`의 `useEffect`가 같은 조건으로 요청을 다시 보내는 구조입니다(코드로 확인했고, 브라우저로 직접 재현하지는 않았습니다).

### 수정

`useListNavigation`과 같은 `URLSearchParams`로 바꿨습니다. 한 줄입니다.

```js
export function getQueryString(params) {
  return `?${new URLSearchParams(params).toString()}`;
}
```

`encodeURIComponent`가 아니라 `URLSearchParams`를 고른 이유는, 이 저장소가 쿼리스트링을 만들 때 쓰는 방식이 그것이고 `src/hooks/useListNavigation.test.jsx:34`가 검색어 `공지`에 대해 `searchWrd=%EA%B3%B5%EC%A7%80`를 이미 단언하고 있어 인코딩 방식이 두 경로에서 같아지기 때문입니다.

### 영향 범위

`getQueryString`은 목록 10곳에서 호출됩니다. 그중 사용자가 자유롭게 입력하는 `searchWrd`를 싣는 것은 7곳입니다.

- `EgovNoticeList.jsx:36` · `EgovGalleryList.jsx:31`
- `EgovAdminNoticeList.jsx:30` · `EgovAdminGalleryList.jsx:30` · `EgovAdminMemberList.jsx:33` · `EgovAdminBoardList.jsx:34` · `EgovAdminUsageList.jsx:34`

나머지 3곳(`EgovDailyList.jsx:102` · `EgovWeeklyList.jsx:198` · `EgovAdminScheduleList.jsx:70`)은 연·월·일만 넘겨 이 결함에 걸리지 않습니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

`src/api/egovFetch.test.js`에 검증 2건을 추가했습니다. 수정 전에는 둘 다 실패합니다.

```
FAIL src/api/egovFetch.test.js > getQueryString > 검색어의 특수문자를 인코딩한다
Expected: "?bbsId=BBSMSTR_AAA&pageIndex=1&searchCnd=0&searchWrd=C%235+%26+C%2B%2B"
Received: "?bbsId=BBSMSTR_AAA&pageIndex=1&searchCnd=0&searchWrd=C#5 & C++"

FAIL src/api/egovFetch.test.js > getQueryString > 인코딩한 쿼리스트링에서 원래 검색어를 되읽을 수 있다
AssertionError: expected 'C' to be 'C#5 & C++'

Test Files  1 failed | 12 passed (13)
     Tests  2 failed | 53 passed (55)
```

수정 후에는 전부 통과합니다.

```
npm run test:run
Test Files  13 passed (13)
     Tests  55 passed (55)

npm run lint     경고 없음
npm run build    ✓ built in 1.05s
```

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

해당 없음 (요청 URL 조립 변경)

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

위 테스트 출력으로 대신합니다.
