### PR TITLE
fix(inform,admin): 등록·수정 화면 breadcrumb 의 게시판 이름이 항상 비는 문제 수정

### DIFF
--- a/src/pages/admin/gallery/EgovAdminGalleryEdit.jsx
+++ b/src/pages/admin/gallery/EgovAdminGalleryEdit.jsx
@@ -131,7 +131,7 @@ function EgovAdminGalleryEdit(props) {
     }
   };
 
-  const Location = React.memo(function Location(masterBoard) {
+  const Location = React.memo(function Location({ masterBoard }) {
     return (
       <div className="location">
         <ul>
@@ -159,7 +159,7 @@ function EgovAdminGalleryEdit(props) {
     <div className="container">
       <div className="c_wrap">
         {/* <!-- Location --> */}
-        <Location />
+        <Location masterBoard={masterBoard} />
         {/* <!--// Location --> */}
 
         <div className="layout">

--- a/src/pages/admin/notice/EgovAdminNoticeEdit.jsx
+++ b/src/pages/admin/notice/EgovAdminNoticeEdit.jsx
@@ -132,7 +132,7 @@ function EgovAdminNoticeEdit(props) {
     }
   };
 
-  const Location = React.memo(function Location(masterBoard) {
+  const Location = React.memo(function Location({ masterBoard }) {
     return (
       <div className="location">
         <ul>
@@ -160,7 +160,7 @@ function EgovAdminNoticeEdit(props) {
     <div className="container">
       <div className="c_wrap">
         {/* <!-- Location --> */}
-        <Location />
+        <Location masterBoard={masterBoard} />
         {/* <!--// Location --> */}
 
         <div className="layout">

--- a/src/pages/inform/gallery/EgovGalleryEdit.jsx
+++ b/src/pages/inform/gallery/EgovGalleryEdit.jsx
@@ -134,7 +134,7 @@ function EgovGalleryEdit(props) {
     }
   };
 
-  const Location = React.memo(function Location(masterBoard) {
+  const Location = React.memo(function Location({ masterBoard }) {
     return (
       <div className="location">
         <ul>
@@ -162,7 +162,7 @@ function EgovGalleryEdit(props) {
     <div className="container">
       <div className="c_wrap">
         {/* <!-- Location --> */}
-        <Location />
+        <Location masterBoard={masterBoard} />
         {/* <!--// Location --> */}
 
         <div className="layout">

--- a/src/pages/inform/notice/EgovNoticeEdit.jsx
+++ b/src/pages/inform/notice/EgovNoticeEdit.jsx
@@ -135,7 +135,7 @@ function EgovNoticeEdit(props) {
     }
   };
 
-  const Location = React.memo(function Location(masterBoard) {
+  const Location = React.memo(function Location({ masterBoard }) {
     return (
       <div className="location">
         <ul>
@@ -163,7 +163,7 @@ function EgovNoticeEdit(props) {
     <div className="container">
       <div className="c_wrap">
         {/* <!-- Location --> */}
-        <Location />
+        <Location masterBoard={masterBoard} />
         {/* <!--// Location --> */}
 
         <div className="layout">

--- a/src/pages/inform/notice/EgovNoticeEdit.test.jsx
+++ b/src/pages/inform/notice/EgovNoticeEdit.test.jsx
@@ -1,0 +1,60 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import EgovNoticeEdit from "@/pages/inform/notice/EgovNoticeEdit";
+import CODE from "@/constants/code";
+
+/**
+ * 등록·수정 화면의 breadcrumb 은 목록·상세와 같은 게시판 이름을 보여야 한다.
+ * Location 이 masterBoard 를 파라미터로 선언해 두고 <Location /> 이 props 없이
+ * 호출되면, 그 이름은 바깥 상태가 아니라 빈 props 객체를 가리켜 항상 비어 있다.
+ */
+const BBS_NM = "공지사항";
+const BBS_ID = "BBSMSTR_AAAAAAAAAAAA";
+
+const detail = {
+  resultCode: 200,
+  result: {
+    brdMstrVO: {
+      bbsNm: BBS_NM,
+      bbsUseFlag: "Y",
+      replyPosblAt: "N",
+      fileAtchPosblAt: "N",
+    },
+    boardVO: {
+      bbsId: BBS_ID,
+      nttId: 1,
+      nttSj: "제목",
+      nttCn: "내용",
+    },
+    resultFiles: [],
+  },
+};
+
+const renderEdit = () =>
+  render(
+    <MemoryRouter
+      initialEntries={[{ pathname: "/", state: { bbsId: BBS_ID, nttId: 1 } }]}
+    >
+      <EgovNoticeEdit mode={CODE.MODE_MODIFY} />
+    </MemoryRouter>
+  );
+
+describe("공지사항 수정 화면 breadcrumb", () => {
+  beforeEach(() => {
+    global.fetch = vi.fn(() =>
+      Promise.resolve({ json: () => Promise.resolve(detail) })
+    );
+  });
+
+  it("breadcrumb 마지막 항목에 게시판 이름이 나온다", async () => {
+    const { container } = renderEdit();
+
+    // 같은 화면의 제목에는 이름이 나온다 — 데이터가 없어서 비는 것이 아니다
+    await screen.findByText(`${BBS_NM} 수정`);
+
+    const breadcrumb = container.querySelector(".location");
+    await waitFor(() => expect(breadcrumb.textContent).toContain(BBS_NM));
+  });
+});


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

## 수정된 소스 내용 Modified source

게시판 등록·수정 화면 넷의 breadcrumb 에서 마지막 항목(게시판 이름)이 항상 비어 있습니다.

`Location` 이 `masterBoard` 를 **함수 파라미터로 선언**해 두는데, 호출은 `<Location />` 으로 props 없이 합니다.

```jsx
const Location = React.memo(function Location(masterBoard) {
  ...
  <li>{masterBoard && masterBoard.bbsNm}</li>
```

그래서 함수 안의 `masterBoard` 는 바깥 상태가 아니라 빈 props 객체를 가리킵니다. `{}` 는 truthy 이므로 `{masterBoard && masterBoard.bbsNm}` 이 `undefined` 로 평가돼 세 번째 `<li>` 가 항상 빕니다.

jsdom 테스트 텍스트와 `src/css/layout.css:272` 의 `.location ul li + li::before` 규칙(화살표를 배경이미지로 붙임)을 보면 브라우저에서는 `Home > 사이트관리 > ` 로 끝나는 breadcrumb 으로 보일 것으로 추정됩니다. 빈 항목도 자리를 차지하기 때문입니다.

### 데이터가 없어서 비는 것이 아닙니다

같은 파일의 제목이 같은 상태로 게시판 이름을 렌더합니다(`EgovNoticeEdit.jsx:182`). 형제인 목록·상세의 breadcrumb 도 같은 값을 렌더합니다(`EgovNoticeList.jsx:123`, `EgovNoticeDetail.jsx:110`) — 그쪽은 `Location` 컴포넌트를 두지 않고 바깥 상태를 그대로 씁니다. 수정 모드의 `masterBoard` 는 목록·상세가 쓰는 것과 같은 `brdMstrVO` 입니다(`EgovNoticeEdit.jsx:93`).

### 수정

파라미터를 구조분해로 바꾸고 호출부에서 상태를 넘겼습니다. 파일당 두 줄입니다.

```jsx
const Location = React.memo(function Location({ masterBoard }) {
...
<Location masterBoard={masterBoard} />
```

파라미터를 지워 바깥 상태를 클로저로 잡는 쪽도 한 줄로 됩니다. `Location` 이 부모 함수 본문 안에서 매 렌더 재정의돼 `React.memo` 가 이미 비교할 기회를 갖지 못하므로, 두 방식의 갱신 동작은 같습니다. 파라미터가 선언돼 있는데 넘기는 쪽이 없는 것이 이 결함의 원인이었던 만큼, 선언과 호출을 맞추는 편이 읽기에 분명하다고 보아 props 를 넘겼습니다.

### 대상 범위

`src` 전체에서 `Location` 정의는 일곱 곳입니다. 그중 `masterBoard` 를 파라미터로 받는 네 곳이 이 결함에 해당합니다.

- `src/pages/inform/notice/EgovNoticeEdit.jsx:138`·`166`
- `src/pages/inform/gallery/EgovGalleryEdit.jsx:137`·`165`
- `src/pages/admin/notice/EgovAdminNoticeEdit.jsx:135`·`163`
- `src/pages/admin/gallery/EgovAdminGalleryEdit.jsx:134`·`162`

수정 전 네 파일의 `Location` 블록은 서로 완전히 동일했습니다. 나머지 세 곳(`EgovDailyList`·`EgovWeeklyList`·`EgovAdminScheduleList`)은 `function Location()` 으로 파라미터가 없고 동적 항목도 없어 대상이 아닙니다. `src` 전체에서 props 를 넘기는 `<Location ...>` 호출은 한 곳도 없었습니다.

## JUnit 테스트 JUnit tests

- [X] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

`src/pages/inform/notice/EgovNoticeEdit.test.jsx` 를 추가했습니다. 수정 전에는 실패합니다.

```
FAIL src/pages/inform/notice/EgovNoticeEdit.test.jsx > 공지사항 수정 화면 breadcrumb > breadcrumb 마지막 항목에 게시판 이름이 나온다
AssertionError: expected 'Home사이트관리' to contain '공지사항'

Test Files  1 failed (1)
     Tests  1 failed (1)
```

같은 테스트가 breadcrumb 을 보기 전에 화면 제목 `공지사항 수정` 이 뜨는 것을 먼저 확인합니다. 데이터가 도착했는데 breadcrumb 만 비어 있음을 같은 실행 안에서 보이기 위한 것입니다.

회귀 테스트는 네 화면 중 공지사항 수정 하나만 덮습니다. 나머지 셋은 수정 전 `Location` 블록이 이 화면과 동일했고 같은 두 줄을 고쳤다는 점에 기대고 있습니다.

수정 후에는 전부 통과합니다.

```
npm run test:run
Test Files  14 passed (14)
     Tests  54 passed (54)

npm run lint     경고 없음
npm run build    성공
```

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

해당 없음 (jsdom 렌더링으로 확인)

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

위 테스트 출력으로 대신합니다.
