### PR TITLE
fix(auth): 관리자 신규 암호 6자 미만 입력 차단

### DIFF
--- a/src/pages/admin/manager/EgovAdminPasswordUpdate.jsx
+++ b/src/pages/admin/manager/EgovAdminPasswordUpdate.jsx
@@ -26,6 +26,10 @@ function EgovAdminPasswordUpdate() {
       alert("신규 암호는 필수 값입니다.");
       return false;
     }
+    if (formData.get("new_password").length < 6) {
+      alert("신규 암호는 6자 이상이어야 합니다.");
+      return false;
+    }
     if (formData.get("new_password") === formData.get("old_password")) {
       alert("신규 암호는 기존 암호와 동일하게 사용할 수 없습니다.");
       return false;

--- a/src/pages/admin/manager/EgovAdminPasswordUpdate.test.jsx
+++ b/src/pages/admin/manager/EgovAdminPasswordUpdate.test.jsx
@@ -1,0 +1,65 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import EgovAdminPasswordUpdate from "@/pages/admin/manager/EgovAdminPasswordUpdate";
+import { requestFetch } from "@/api/egovFetch";
+
+vi.mock("@/api/egovFetch", () => ({ requestFetch: vi.fn() }));
+
+describe("관리자 비밀번호 변경 검증", () => {
+  beforeEach(() => {
+    vi.spyOn(window, "alert").mockImplementation(() => {});
+    requestFetch.mockReset();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  const changePassword = (newPassword, confirmPassword = newPassword, oldPassword = "old-password") => {
+    render(
+      <MemoryRouter>
+        <EgovAdminPasswordUpdate />
+      </MemoryRouter>
+    );
+    fireEvent.change(screen.getByLabelText("기존 암호"), { target: { value: oldPassword } });
+    fireEvent.change(screen.getByLabelText("신규 암호"), { target: { value: newPassword } });
+    fireEvent.change(screen.getByLabelText("입력 확인"), { target: { value: confirmPassword } });
+    fireEvent.click(screen.getByRole("button", { name: "변경" }));
+  };
+
+  it.each(["a", "abcde"])("6자 미만 신규 암호 %s는 요청 전에 거부한다", (password) => {
+    changePassword(password);
+
+    expect(window.alert).toHaveBeenCalledWith("신규 암호는 6자 이상이어야 합니다.");
+    expect(requestFetch).not.toHaveBeenCalled();
+  });
+
+  it.each(["abcdef", "새비밀번호1", " abcde "])("6자 이상 신규 암호 %s는 원문 그대로 전송한다", (password) => {
+    changePassword(password);
+
+    expect(window.alert).not.toHaveBeenCalled();
+    expect(requestFetch).toHaveBeenCalledTimes(1);
+    const [url, options] = requestFetch.mock.calls[0];
+    expect(url).toBe("/admin/password");
+    expect(options.method).toBe("PATCH");
+    expect(JSON.parse(options.body)).toEqual({
+      old_password: "old-password",
+      new_password: password,
+    });
+  });
+
+  it.each([
+    ["", "", "old-password", "신규 암호는 필수 값입니다."],
+    ["abcdef", "abcdef", "", "기존 암호는 필수 값입니다."],
+    ["old-password", "old-password", "old-password", "신규 암호는 기존 암호와 동일하게 사용할 수 없습니다."],
+    ["abcdef", "different", "old-password", "신규 암호와 입력 확인값이 일치하지 않습니다"],
+  ])("기존 입력 검사를 유지한다: %s / %s", (password, confirmation, oldPassword, message) => {
+    changePassword(password, confirmation, oldPassword);
+
+    expect(window.alert).toHaveBeenCalledWith(message);
+    expect(requestFetch).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

관리자 암호 변경 화면은 6자 미만의 신규 암호도 전송하지만 로그인 화면은 같은 길이의 입력을 차단하고 있었습니다. 로그인 기준에 맞지 않는 암호 변경 요청을 보내기 전에 사용자에게 안내하도록 수정했습니다.

## 수정된 소스 내용 Modified source

- 신규 암호가 6자 미만이면 안내하고 변경 요청을 중단합니다.
- 길이 경계값과 공백 유지, 필수값·동일 암호·확인값 불일치 검사를 확인하는 컴포넌트 테스트 9개를 추가했습니다.

관련 백엔드 변경: https://github.com/eGovFramework/egovframe-template-simple-backend/pull/214

## JUnit 테스트 JUnit tests

- [ ] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

Node.js 22에서 Vitest 전체 62개 테스트, 제품 빌드와 변경 파일 ESLint 검사가 통과했습니다.

실제 백엔드를 연결한 React·Chrome 화면 자동 검증으로 5자 입력 시 안내 및 요청 미전송, 정확히 6자로 변경 후 재로그인 성공을 확인했습니다. 기존 암호로는 로그인이 실패했습니다.

## 테스트 브라우저 Test Browser

- [X] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

암호를 정확히 6자로 변경하고 로그아웃한 뒤 새 암호로 재로그인한 메인 화면입니다. 입력 검증 경고 화면의 캡처는 없으며, 요청 차단은 컴포넌트 테스트와 실제 Chrome 검증으로 확인했습니다.

![신규 암호로 재로그인한 뒤 메인 화면](https://raw.githubusercontent.com/wizlife/egovframe-template-simple-backend/ee9fb24b5aa5e90f4fb9fe2cd55b6de72d906ebc/screenshots/admin-relogin-success.png)
