### PR TITLE
fix(schedule): 삭제된 일정 조회 시 안내 후 목록 복귀

### DIFF
--- a/src/constants/code.js
+++ b/src/constants/code.js
@@ -2,6 +2,7 @@ const CODE = {
     RCV_SUCCESS             : "200", // 성공
     
     RCV_ERROR_AUTH          : "403", // 인증 오류
+    RCV_ERROR_NOT_FOUND     : "404", // 조회 대상 없음
     RCV_ERROR_DELETE        : "700", // 삭제 오류
     RCV_ERROR_SAVE          : "800", // 저장 오류
     RCV_ERROR_VALIDATION    : "900", // 입력 오류

--- a/src/pages/admin/schedule/EgovAdminScheduleDetail.jsx
+++ b/src/pages/admin/schedule/EgovAdminScheduleDetail.jsx
@@ -27,7 +27,21 @@ function EgovAdminScheduleDetail() {
       },
     };
     EgovNet.requestFetch(retrieveDetailURL, requestOptions, function (resp) {
-      let rawScheduleDetail = resp.result.scheduleDetail;
+      const resultCode = Number(resp.resultCode);
+      const rawScheduleDetail = resp.result?.scheduleDetail;
+      if (resultCode === Number(CODE.RCV_ERROR_NOT_FOUND) ||
+          (resultCode === Number(CODE.RCV_SUCCESS) && !rawScheduleDetail)) {
+        alert("일정이 존재하지 않거나 삭제되었습니다.");
+        navigate(URL.ADMIN_SCHEDULE, {
+          replace: true,
+          state: { searchCondition: location.state?.searchCondition },
+        });
+        return;
+      }
+      if (resultCode !== Number(CODE.RCV_SUCCESS)) {
+        navigate({ pathname: URL.ERROR }, { state: { msg: resp.resultMessage } });
+        return;
+      }
       rawScheduleDetail.startDateTime = convertDate(
         rawScheduleDetail.schdulBgnde
       );
@@ -209,6 +223,7 @@ function EgovAdminScheduleDetail() {
                       to={{ pathname: URL.ADMIN_SCHEDULE_MODIFY }}
                       state={{
                         schdulId: location.state?.schdulId,
+                        searchCondition: location.state?.searchCondition,
                       }}
                       className="btn btn_skyblue_h46 w_100"
                     >
@@ -227,6 +242,7 @@ function EgovAdminScheduleDetail() {
                 <div className="right_col btn1">
                   <Link
                     to={URL.ADMIN_SCHEDULE}
+                    state={{ searchCondition: location.state?.searchCondition }}
                     className="btn btn_blue_h46 w_100"
                   >
                     목록

--- a/src/pages/admin/schedule/EgovAdminScheduleEdit.jsx
+++ b/src/pages/admin/schedule/EgovAdminScheduleEdit.jsx
@@ -96,7 +96,21 @@ function EgovAdminScheduleEdit(props) {
       },
     };
     EgovNet.requestFetch(retrieveDetailURL, requestOptions, function (resp) {
-      let rawScheduleDetail = resp.result.scheduleDetail;
+      const resultCode = Number(resp.resultCode);
+      const rawScheduleDetail = resp.result?.scheduleDetail;
+      if (resultCode === Number(CODE.RCV_ERROR_NOT_FOUND) ||
+          (resultCode === Number(CODE.RCV_SUCCESS) && !rawScheduleDetail)) {
+        alert("일정이 존재하지 않거나 삭제되었습니다.");
+        navigate(URL.ADMIN_SCHEDULE, {
+          replace: true,
+          state: { searchCondition: location.state?.searchCondition },
+        });
+        return;
+      }
+      if (resultCode !== Number(CODE.RCV_SUCCESS)) {
+        navigate({ pathname: URL.ERROR }, { state: { msg: resp.resultMessage } });
+        return;
+      }
       //기본값 설정
       setScheduleDetail({
         ...scheduleDetail,
@@ -486,6 +500,7 @@ function EgovAdminScheduleEdit(props) {
                 <div className="right_col btn1">
                   <Link
                     to={URL.ADMIN_SCHEDULE}
+                    state={{ searchCondition: location.state?.searchCondition }}
                     className="btn btn_blue_h46 w_100"
                   >
                     목록

--- a/src/pages/admin/schedule/EgovAdminScheduleList.jsx
+++ b/src/pages/admin/schedule/EgovAdminScheduleList.jsx
@@ -200,7 +200,7 @@ function EgovAdminScheduleList() {
                           <>
                             <Link
                               to={{ pathname: URL.ADMIN_SCHEDULE_DETAIL }}
-                              state={{ schdulId: schedule.schdulId }}
+                              state={{ schdulId: schedule.schdulId, searchCondition }}
                               key={keyIdx++}
                             >
                               {schedule.schdulNm}

--- a/src/pages/admin/schedule/EgovAdminScheduleMissingDetail.test.jsx
+++ b/src/pages/admin/schedule/EgovAdminScheduleMissingDetail.test.jsx
@@ -1,0 +1,175 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { MemoryRouter, Route, Routes, useLocation, useNavigationType } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import * as EgovNet from "@/api/egovFetch";
+import CODE from "@/constants/code";
+import URL from "@/constants/url";
+import EgovAdminScheduleDetail from "@/pages/admin/schedule/EgovAdminScheduleDetail";
+import EgovAdminScheduleEdit from "@/pages/admin/schedule/EgovAdminScheduleEdit";
+import EgovAdminScheduleList from "@/pages/admin/schedule/EgovAdminScheduleList";
+
+vi.mock("@/api/egovFetch", async (importOriginal) => ({
+  ...await importOriginal(), requestFetch: vi.fn(),
+}));
+
+const SCHEDULE_ID = "SCHDUL_0000000000001";
+const SEARCH_CONDITION = { year: 2026, month: 8, date: 8, schdulSe: "1" };
+
+function Destination() {
+  const location = useLocation();
+  return <output data-testid="destination">{JSON.stringify({
+    pathname: location.pathname,
+    state: location.state,
+    navigationType: useNavigationType(),
+  })}</output>;
+}
+
+function renderSchedule(element, state = { schdulId: SCHEDULE_ID, searchCondition: SEARCH_CONDITION }) {
+  return render(
+    <MemoryRouter initialEntries={[{ pathname: "/test-schedule", state }]}>
+      <Routes>
+        <Route path="/test-schedule" element={element} />
+        <Route path={URL.ADMIN_SCHEDULE} element={<Destination />} />
+        <Route path={URL.ADMIN_SCHEDULE_DETAIL} element={<Destination />} />
+        <Route path={URL.ADMIN_SCHEDULE_MODIFY} element={<Destination />} />
+        <Route path={URL.ERROR} element={<Destination />} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+function detailResponse(attachments = []) {
+  return {
+    resultCode: 200,
+    result: {
+      scheduleDetail: {
+        schdulId: SCHEDULE_ID,
+        schdulNm: "정기 회의",
+        schdulCn: "진행 상황 공유",
+        schdulSe: "1",
+        schdulIpcrCode: "A",
+        reptitSeCode: "1",
+        schdulBgnde: "202609081000",
+        schdulEndde: "202609081100",
+        atchFileId: attachments.length ? "encodedFileId==" : "",
+      },
+      schdulSe: [{ code: "1", codeNm: "부서일정" }],
+      schdulIpcrCode: [{ code: "A", codeNm: "높음" }],
+      reptitSeCode: [{ code: "1", codeNm: "당일" }],
+      resultFiles: attachments,
+      user: { id: "admin" },
+    },
+  };
+}
+
+function respondWith(response) {
+  EgovNet.requestFetch.mockImplementation((_url, _options, handler) => handler(response));
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.spyOn(window, "alert").mockImplementation(() => {});
+});
+
+afterEach(() => vi.restoreAllMocks());
+
+describe.each([
+  ["상세", <EgovAdminScheduleDetail key="detail" />],
+  ["수정", <EgovAdminScheduleEdit key="modify" mode={CODE.MODE_MODIFY} />],
+])("일정 %s 화면", (_name, element) => {
+  it.each([
+    ["없는 일정", { resultCode: 404, result: {} }],
+    ["삭제된 일정", { resultCode: "404", result: { scheduleDetail: null } }],
+    ["성공 응답에 상세 결과 없음", { resultCode: 200, result: {} }],
+  ])("%s은 안내 후 기존 검색 조건의 목록으로 이동한다", (_scenario, response) => {
+    respondWith(response);
+
+    renderSchedule(element);
+
+    expect(window.alert).toHaveBeenCalledExactlyOnceWith("일정이 존재하지 않거나 삭제되었습니다.");
+    expect(JSON.parse(screen.getByTestId("destination").textContent)).toEqual({
+      pathname: URL.ADMIN_SCHEDULE,
+      state: { searchCondition: SEARCH_CONDITION },
+      navigationType: "REPLACE",
+    });
+    expect(EgovNet.requestFetch).toHaveBeenCalledTimes(1);
+    expect(EgovNet.requestFetch).toHaveBeenCalledWith(
+      `/schedule/${SCHEDULE_ID}`, expect.objectContaining({ method: "GET" }), expect.any(Function)
+    );
+  });
+
+  it("다른 오류 응답은 일정 부재로 안내하지 않고 오류 화면으로 보낸다", () => {
+    respondWith({ resultCode: 800, resultMessage: "요청 처리 실패", result: {} });
+
+    renderSchedule(element);
+
+    expect(window.alert).not.toHaveBeenCalled();
+    const destination = JSON.parse(screen.getByTestId("destination").textContent);
+    expect(destination.pathname).toBe(URL.ERROR);
+    expect(destination.state).toEqual({ msg: "요청 처리 실패" });
+  });
+
+  it.each([false, true])("정상 일정의 내용과 첨부파일을 유지한다 (첨부: %s)", (hasAttachment) => {
+    const attachments = hasAttachment ? [{
+      atchFileId: "encodedFileId==", fileSn: "0", orignlFileNm: "schedule.xlsx", fileMg: "3",
+    }] : [];
+    respondWith(detailResponse(attachments));
+
+    renderSchedule(element);
+
+    expect(screen.queryByTestId("destination")).not.toBeInTheDocument();
+    expect(window.alert).not.toHaveBeenCalled();
+    if (_name === "상세") {
+      expect(screen.getByText("정기 회의")).toBeInTheDocument();
+      expect(screen.getByText("진행 상황 공유")).toBeInTheDocument();
+      expect(screen.getByText(/2026년 09월 08일 10시 00분/)).toBeInTheDocument();
+    } else {
+      expect(screen.getByDisplayValue("정기 회의")).toBeInTheDocument();
+      expect(screen.getByDisplayValue("진행 상황 공유")).toBeInTheDocument();
+    }
+    if (hasAttachment) {
+      const open = vi.spyOn(window, "open").mockImplementation(() => null);
+      fireEvent.click(screen.getByRole("link", { name: "schedule.xlsx" }));
+      expect(open).toHaveBeenCalledWith(
+        expect.stringContaining("/file?atchFileId=encodedFileId%3D%3D&fileSn=0"),
+        "_blank", "noopener,noreferrer"
+      );
+      expect(screen.getByText("[3byte]")).toBeInTheDocument();
+    } else {
+      expect(screen.queryByRole("link", { name: "schedule.xlsx" })).not.toBeInTheDocument();
+    }
+  });
+});
+
+it("신규 등록은 상세 조회 없이 선택한 날짜로 입력 화면을 연다", () => {
+  renderSchedule(<EgovAdminScheduleEdit mode={CODE.MODE_CREATE} />, { iUseDate: "20260908000000" });
+
+  expect(EgovNet.requestFetch).not.toHaveBeenCalled();
+  expect(window.alert).not.toHaveBeenCalled();
+  expect(screen.queryByTestId("destination")).not.toBeInTheDocument();
+  expect(screen.getByRole("button", { name: "저장" })).toBeInTheDocument();
+  expect(screen.getAllByDisplayValue("2026-09-08 00:00")).toHaveLength(2);
+});
+
+it("목록의 월과 일정구분을 상세 화면으로 전달한다", () => {
+  respondWith({ resultCode: 200, result: { resultList: [detailResponse().result.scheduleDetail] } });
+
+  renderSchedule(<EgovAdminScheduleList />, { searchCondition: SEARCH_CONDITION });
+  fireEvent.click(screen.getByRole("link", { name: "정기 회의" }));
+
+  const destination = JSON.parse(screen.getByTestId("destination").textContent);
+  expect(destination.pathname).toBe(URL.ADMIN_SCHEDULE_DETAIL);
+  expect(destination.state).toEqual({ schdulId: SCHEDULE_ID, searchCondition: SEARCH_CONDITION });
+});
+
+it("상세 화면에서 수정 화면으로 이동해도 목록 검색 조건을 유지한다", () => {
+  respondWith(detailResponse());
+
+  renderSchedule(<EgovAdminScheduleDetail />);
+  fireEvent.click(screen.getByRole("link", { name: "수정" }));
+
+  const destination = JSON.parse(screen.getByTestId("destination").textContent);
+  expect(destination.pathname).toBe(URL.ADMIN_SCHEDULE_MODIFY);
+  expect(destination.state).toEqual({ schdulId: SCHEDULE_ID, searchCondition: SEARCH_CONDITION });
+});

--- a/src/pages/inform/daily/EgovDailyDetail.jsx
+++ b/src/pages/inform/daily/EgovDailyDetail.jsx
@@ -1,14 +1,16 @@
 import { useState, useEffect } from "react";
-import { Link, useLocation } from "react-router-dom";
+import { Link, useLocation, useNavigate } from "react-router-dom";
 
 import * as EgovNet from "@/api/egovFetch";
 import URL from "@/constants/url";
+import CODE from "@/constants/code";
 
 import { default as EgovLeftNav } from "@/components/leftmenu/EgovLeftNavInform";
 import EgovAttachFile from "@/components/EgovAttachFile";
 
 function EgovDailyDetail() {
 
+  const navigate = useNavigate();
   const location = useLocation();
 
   const [scheduleDetail, setScheduleDetail] = useState({});
@@ -23,7 +25,23 @@ function EgovDailyDetail() {
       },
     };
     EgovNet.requestFetch(retrieveDetailURL, requestOptions, function (resp) {
-      let rawScheduleDetail = resp.result.scheduleDetail;
+      const resultCode = Number(resp.resultCode);
+      const rawScheduleDetail = resp.result?.scheduleDetail;
+      if (resultCode === Number(CODE.RCV_ERROR_NOT_FOUND) ||
+          (resultCode === Number(CODE.RCV_SUCCESS) && !rawScheduleDetail)) {
+        alert("일정이 존재하지 않거나 삭제되었습니다.");
+        const listURL = location.state?.prevPath === URL.INFORM_WEEKLY
+          ? URL.INFORM_WEEKLY : URL.INFORM_DAILY;
+        navigate(listURL, {
+          replace: true,
+          state: { searchCondition: location.state?.searchCondition },
+        });
+        return;
+      }
+      if (resultCode !== Number(CODE.RCV_SUCCESS)) {
+        navigate({ pathname: URL.ERROR }, { state: { msg: resp.resultMessage } });
+        return;
+      }
       rawScheduleDetail.startDateTime = convertDate(
         rawScheduleDetail.schdulBgnde
       );

--- a/src/pages/inform/daily/EgovDailyDetail.test.jsx
+++ b/src/pages/inform/daily/EgovDailyDetail.test.jsx
@@ -1,0 +1,102 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { MemoryRouter, Route, Routes, useLocation, useNavigationType } from "react-router-dom";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+
+import * as EgovNet from "@/api/egovFetch";
+import URL from "@/constants/url";
+import EgovDailyDetail from "@/pages/inform/daily/EgovDailyDetail";
+
+vi.mock("@/api/egovFetch", () => ({ requestFetch: vi.fn() }));
+
+const SEARCH_CONDITION = { year: 2026, month: 8, date: 8, schdulSe: "1" };
+
+function Destination() {
+  const location = useLocation();
+  return <output data-testid="destination">{JSON.stringify({
+    pathname: location.pathname, state: location.state, navigationType: useNavigationType(),
+  })}</output>;
+}
+
+function renderDetail(response, prevPath = URL.INFORM_DAILY) {
+  EgovNet.requestFetch.mockImplementation((_url, _options, handler) => handler(response));
+  return render(
+    <MemoryRouter initialEntries={[{ pathname: "/test-detail", state: {
+      schdulId: "SCHDUL_0000000000001", prevPath, searchCondition: SEARCH_CONDITION,
+    } }]}>
+      <Routes>
+        <Route path="/test-detail" element={<EgovDailyDetail />} />
+        <Route path={URL.INFORM_DAILY} element={<Destination />} />
+        <Route path={URL.INFORM_WEEKLY} element={<Destination />} />
+        <Route path={URL.ERROR} element={<Destination />} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.spyOn(window, "alert").mockImplementation(() => {});
+});
+
+afterEach(() => vi.restoreAllMocks());
+
+it.each([
+  ["없는 일정", { resultCode: 404, result: {} }, URL.INFORM_DAILY, URL.INFORM_DAILY],
+  ["삭제된 일정", { resultCode: "404", result: { scheduleDetail: null } }, URL.INFORM_WEEKLY, URL.INFORM_WEEKLY],
+  ["성공 응답에 상세 결과 없음", { resultCode: 200, result: {} }, URL.INFORM_WEEKLY, URL.INFORM_WEEKLY],
+  ["이전 목록 정보 없음", { resultCode: 404, result: {} }, null, URL.INFORM_DAILY],
+  ["이전 목록이 일정 목록이 아님", { resultCode: 404, result: {} }, URL.ADMIN, URL.INFORM_DAILY],
+])("%s은 안내 후 해당 일정 목록으로 이동한다", (_scenario, response, prevPath, expectedPath) => {
+  renderDetail(response, prevPath);
+
+  expect(window.alert).toHaveBeenCalledExactlyOnceWith("일정이 존재하지 않거나 삭제되었습니다.");
+  expect(JSON.parse(screen.getByTestId("destination").textContent)).toEqual({
+    pathname: expectedPath,
+    state: { searchCondition: SEARCH_CONDITION },
+    navigationType: "REPLACE",
+  });
+  expect(EgovNet.requestFetch).toHaveBeenCalledTimes(1);
+});
+
+it("다른 오류는 일정 부재로 안내하지 않고 오류 화면으로 보낸다", () => {
+  renderDetail({ resultCode: 800, resultMessage: "요청 처리 실패", result: {} });
+
+  expect(window.alert).not.toHaveBeenCalled();
+  const destination = JSON.parse(screen.getByTestId("destination").textContent);
+  expect(destination.pathname).toBe(URL.ERROR);
+  expect(destination.state).toEqual({ msg: "요청 처리 실패" });
+});
+
+it.each([false, true])("정상 일정의 내용·날짜·첨부를 유지한다 (첨부: %s)", (hasAttachment) => {
+  renderDetail({
+    resultCode: 200,
+    result: {
+      scheduleDetail: {
+        schdulNm: "정기 회의", schdulCn: "진행 상황 공유",
+        schdulBgnde: "202609081000", schdulEndde: "202609081100",
+        schdulSe: "1", schdulIpcrCode: "A", reptitSeCode: "1",
+      },
+      schdulSe: [{ code: "1", codeNm: "회의" }],
+      schdulIpcrCode: [{ code: "A", codeNm: "높음" }],
+      reptitSeCode: [{ code: "1", codeNm: "당일" }],
+      resultFiles: hasAttachment ? [{
+        atchFileId: "encodedFileId==", fileSn: "0", orignlFileNm: "schedule.xlsx", fileMg: "3",
+      }] : [],
+    },
+  });
+
+  expect(window.alert).not.toHaveBeenCalled();
+  expect(screen.getByText("정기 회의")).toBeInTheDocument();
+  expect(screen.getByText("진행 상황 공유")).toBeInTheDocument();
+  expect(screen.getByText(/2026년 09월 08일 10시 00분/)).toBeInTheDocument();
+  if (hasAttachment) {
+    const open = vi.spyOn(window, "open").mockImplementation(() => null);
+    fireEvent.click(screen.getByRole("link", { name: "schedule.xlsx" }));
+    expect(open).toHaveBeenCalledWith(
+      expect.stringContaining("/file?atchFileId=encodedFileId%3D%3D&fileSn=0"),
+      "_blank", "noopener,noreferrer"
+    );
+  } else {
+    expect(screen.queryByRole("link", { name: "schedule.xlsx" })).not.toBeInTheDocument();
+  }
+});


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [X] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [ ] 기타 Others

목록을 연 뒤 다른 요청으로 일정이 삭제되면 상세·수정 화면이 없는 상세 데이터를 읽어 오류가 발생합니다. 부재 응답을 안내하고 목록으로 돌아가도록 처리합니다.

## 수정된 소스 내용 Modified source

- 관리자 상세·수정과 오늘·금주 행사 상세에서 본문 resultCode 404 또는 성공 응답의 빈 상세 결과를 처리합니다.
- 관리자 목록의 월·일정구분을 유지하고, 부재·정상 응답에 대한 컴포넌트 테스트를 추가합니다.

연동 백엔드 PR: [#217](https://github.com/eGovFramework/egovframe-template-simple-backend/pull/217)

## JUnit 테스트 JUnit tests

- [ ] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

- 관련 Vitest 26개, 변경 파일 ESLint 및 배포용 빌드 통과.
- 실제 백엔드·HSQL을 연결한 Chrome 자동 검증: 네 화면의 삭제 안내 후 목록 복귀, 관리자 검색 조건 유지, 정상 상세·수정 데이터·첨부 다운로드 확인.

연동 검증은 이번 백엔드 개선 4건을 함께 반영한 환경에서 수행했습니다. JUnit·수동 테스트 대신 Vitest와 브라우저 자동 검증을 진행했습니다.

## 테스트 브라우저 Test Browser

- [X] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

배포용 빌드에서 부재 안내를 확인한 뒤 돌아온 목록입니다. 대화상자와 실제 API 응답은 [테스트 결과](https://github.com/wizlife/egovframe-template-simple-backend/blob/dd9537beec20a9564704de342704a6e351533d26/TEST_RESULTS.md)로 별도 검증했습니다.

<details>
<summary>검증 화면 보기</summary>

![관리자 검색 조건을 유지한 목록 복귀](https://raw.githubusercontent.com/wizlife/egovframe-template-simple-backend/dd9537beec20a9564704de342704a6e351533d26/screenshots/schedule-admin-return.png)

![오늘의 행사 목록 복귀](https://raw.githubusercontent.com/wizlife/egovframe-template-simple-backend/dd9537beec20a9564704de342704a6e351533d26/screenshots/schedule-daily-return.png)

![금주의 행사 목록 복귀](https://raw.githubusercontent.com/wizlife/egovframe-template-simple-backend/dd9537beec20a9564704de342704a6e351533d26/screenshots/schedule-weekly-return.png)

</details>
