### PR TITLE
fix: bbsFormVaildator 오타 수정 (Vaild → Valid)

### DIFF
--- a/src/pages/admin/gallery/EgovAdminGalleryEdit.jsx
+++ b/src/pages/admin/gallery/EgovAdminGalleryEdit.jsx
@@ -9,7 +9,7 @@ import { GALLERY_BBS_ID } from "@/config";
 
 import { default as EgovLeftNav } from "@/components/leftmenu/EgovLeftNavAdmin";
 import EgovAttachFile from "@/components/EgovAttachFile";
-import bbsFormVaildator from "@/utils/bbsFormVaildator";
+import bbsFormValidator from "@/utils/bbsFormValidator";
 import { useDebouncedInput } from "@/hooks/useDebounce";
 
 function EgovAdminGalleryEdit(props) {
@@ -111,7 +111,7 @@ function EgovAdminGalleryEdit(props) {
       formData.append(key, boardDetail[key]);
     }
 
-    if (bbsFormVaildator(formData)) {
+    if (bbsFormValidator(formData)) {
       const requestOptions = {
         method: modeInfo.method,
         body: formData,

--- a/src/pages/admin/notice/EgovAdminNoticeEdit.jsx
+++ b/src/pages/admin/notice/EgovAdminNoticeEdit.jsx
@@ -9,7 +9,7 @@ import { NOTICE_BBS_ID } from "@/config";
 
 import { default as EgovLeftNav } from "@/components/leftmenu/EgovLeftNavAdmin";
 import EgovAttachFile from "@/components/EgovAttachFile";
-import bbsFormVaildator from "@/utils/bbsFormVaildator";
+import bbsFormValidator from "@/utils/bbsFormValidator";
 
 import { useDebouncedInput } from "@/hooks/useDebounce";
 
@@ -112,7 +112,7 @@ function EgovAdminNoticeEdit(props) {
       formData.append(key, boardDetail[key]);
     }
 
-    if (bbsFormVaildator(formData)) {
+    if (bbsFormValidator(formData)) {
       const requestOptions = {
         method: modeInfo.method,
         body: formData,

--- a/src/pages/inform/gallery/EgovGalleryEdit.jsx
+++ b/src/pages/inform/gallery/EgovGalleryEdit.jsx
@@ -9,7 +9,7 @@ import { GALLERY_BBS_ID } from "@/config";
 
 import { default as EgovLeftNav } from "@/components/leftmenu/EgovLeftNavInform";
 import EgovAttachFile from "@/components/EgovAttachFile";
-import bbsFormVaildator from "@/utils/bbsFormVaildator";
+import bbsFormValidator from "@/utils/bbsFormValidator";
 import { useAuth } from "@/contexts/AuthContext";
 import { useDebouncedInput } from "@/hooks/useDebounce";
 
@@ -114,7 +114,7 @@ function EgovGalleryEdit(props) {
       formData.append(key, boardDetail[key]);
     }
 
-    if (bbsFormVaildator(formData)) {
+    if (bbsFormValidator(formData)) {
       const requestOptions = {
         method: modeInfo.method,
         body: formData,

--- a/src/pages/inform/notice/EgovNoticeEdit.jsx
+++ b/src/pages/inform/notice/EgovNoticeEdit.jsx
@@ -9,7 +9,7 @@ import { NOTICE_BBS_ID } from "@/config";
 
 import { default as EgovLeftNav } from "@/components/leftmenu/EgovLeftNavInform";
 import EgovAttachFile from "@/components/EgovAttachFile";
-import bbsFormVaildator from "@/utils/bbsFormVaildator";
+import bbsFormValidator from "@/utils/bbsFormValidator";
 import { useAuth } from "@/contexts/AuthContext";
 import { useDebouncedInput } from "@/hooks/useDebounce";
 
@@ -115,7 +115,7 @@ function EgovNoticeEdit(props) {
       formData.append(key, boardDetail[key]);
     }
 
-    if (bbsFormVaildator(formData)) {
+    if (bbsFormValidator(formData)) {
       const requestOptions = {
         method: modeInfo.method,
         body: formData,

--- a/src/utils/bbsFormValidator.js
+++ b/src/utils/bbsFormValidator.js
@@ -1,4 +1,4 @@
-const bbsFormVaildator = (formData) => {
+const bbsFormValidator = (formData) => {
     if (formData.get('nttSj') === null || formData.get('nttSj') === "") {
         alert("제목은 필수 값입니다.");
         return false;
@@ -10,4 +10,4 @@ const bbsFormVaildator = (formData) => {
     return true;
 };
 
-export default bbsFormVaildator;
+export default bbsFormValidator;


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [ ] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [X] 기타 Others

## 수정된 소스 내용 Modified source

bbsFormVaildator.js 의 오타(`Vaild` → `Valid`)를 수정합니다.
: bbsFormVaildator.js 파일명 및 내부 함수명, 참조하는 4개 파일의 import 경로와 호출부를 bbsFormValidator로 수정합니다.

변경 파일:
- src/utils/bbsFormVaildator.js → src/utils/bbsFormValidator.js
- src/pages/admin/gallery/EgovAdminGalleryEdit.jsx
- src/pages/admin/notice/EgovAdminNoticeEdit.jsx
- src/pages/inform/gallery/EgovGalleryEdit.jsx
- src/pages/inform/notice/EgovNoticeEdit.jsx

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [ ] JUnit 테스트 JUnit tests
- [X] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [X] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡처 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.

N/A - 오타 수정(파일명/함수명 변경)으로 UI 변화 없음
